### PR TITLE
ENH: Record property and doc updates

### DIFF
--- a/docs/source/daq_basic.rst
+++ b/docs/source/daq_basic.rst
@@ -33,7 +33,17 @@ Creating a Daq object
 First, I will set up the `Daq` class in simulated mode. In practice, the
 `Daq` class will be set up for you in the ``hutch-python`` configuration.
 
+.. code-block:: python
+
+    from pcdsdaq.daq import Daq
+    from pcdsdaq.sim import set_sim_mode
+
+    set_sim_mode(True)
+    daq = Daq(platform=4)  # Defined per hutch
+
+
 .. ipython:: python
+    :suppress:
 
     import time
     from pcdsdaq.daq import Daq

--- a/docs/source/daq_basic.rst
+++ b/docs/source/daq_basic.rst
@@ -110,19 +110,19 @@ We can pass ``wait=True`` to skip the `Daq.wait` call.
 
 Recording Data
 --------------
-You can call `Daq.record` to record data. This is fairly simple:
+You can set `Daq.record` to ``True`` to record data. This is fairly simple:
 
 .. ipython:: python
 
-    daq.record()
+    daq.record = True
 
 
 After this call, future calls to `Daq.begin` will record data to disk.
-You can undo this by simply calling:
+You can undo this by simply setting:
 
 .. ipython:: python
 
-    daq.record(False)
+    daq.record = False
 
 
 Advanced Options

--- a/docs/source/daq_basic.rst
+++ b/docs/source/daq_basic.rst
@@ -8,6 +8,23 @@ and start running the daq all in one call. `Daq.stop` can be used to stop
 acquiring data without ending a run. `Daq.begin` can be called again to
 resume a stopped run. `Daq.end_run` will end the run.
 
+`Daq.state` can be used to inspect what the daq is currently doing. It will
+return one of the following possibilities:
+
++------------------+------------------------------------------------+
+| State            | Meaning                                        |
++==================+================================================+
+| ``Disconnected`` | We are not controlling the daq                 |
++------------------+------------------------------------------------+
+| ``Connected``    | We are controlling the daq                     |
++------------------+------------------------------------------------+
+| ``Configured``   | ``Connected``, and `configure` has been called |
++------------------+------------------------------------------------+
+| ``Open``         | ``Configured``, and we are in a run            |
++------------------+------------------------------------------------+
+| ``Running``      | ``Open``, and we are collecting data           |
++------------------+------------------------------------------------+
+
 I will step through the basic options for `Daq.begin` below. You can consult
 the full `api docs <./daq_api>` for more information.
 
@@ -30,14 +47,20 @@ Running Until Stop
 ------------------
 Calling `Daq.begin` with no arguments in the default configuration will
 run the daq indefinitely, until we manually stop it.
+Here I check `Daq.state` to verify that we've started running the daq.
 
 .. ipython:: python
 
+    daq.state
     start = time.time()
     daq.begin()
+    daq.state
     time.sleep(1)
     daq.stop()
     print(time.time() - start)
+    daq.state
+    daq.end_run()
+    daq.state
 
 
 Running for a Fixed Number of Events
@@ -48,37 +71,48 @@ Optionally, we can call `Daq.wait` to pause until acquisition is complete.
 
 .. ipython:: python
 
+    daq.state
     start = time.time()
     daq.begin(events=240)  # 120Hz
+    daq.state
     daq.wait()
     print(time.time() - start)
+    daq.state
+    daq.end_run()
+    daq.state
 
 
 Runing for a Fixed Time Duration
 --------------------------------
 Use the ``duration`` argument to specify duration in seconds.
-We can pass the ``wait`` argument to skip the `Daq.wait` call.
+We can pass ``wait=True`` to skip the `Daq.wait` call.
 
 .. ipython:: python
 
+    daq.state
     start = time.time()
     daq.begin(duration=1.5, wait=True)
     print(time.time() - start)
+    daq.state
+    daq.end_run()
+    daq.state
 
 
 Recording Data
 --------------
-You must call `Daq.configure` to record data. This is fairly simple:
+You can call `Daq.record` to record data. This is fairly simple:
 
 .. ipython:: python
-    daq.configure(record=True)
+
+    daq.record()
 
 
 After this call, future calls to `Daq.begin` will record data to disk.
-You can undo this the same way:
+You can undo this by simply calling:
 
 .. ipython:: python
-    daq.configure(record=False)
+
+    daq.record(False)
 
 
 Advanced Options

--- a/docs/source/daq_config.rst
+++ b/docs/source/daq_config.rst
@@ -3,7 +3,7 @@ Configuration
 Some manual configuration is necessary to record data or to run
 special ``bluesky`` plans with daq support.
 
-In general, there are two kinds of ``Daq.configure`` arguments:
+In general, there are two kinds of `Daq.configure` arguments:
 those that are shared with `Daq.begin`, and those that are not.
 
 Arguments that are shared between the two methods act as defaults.
@@ -11,7 +11,7 @@ For example, calling ``daq.configure(duration=3)`` will set the
 no-arguments behavior of ``daq.begin()`` to run the daq for 3 seconds.
 
 The additional arguments are parameters that can only be changed
-through the ``Daq.configure`` method.  ``record`` is a parameter that
+through the `Daq.configure` method.  ``record`` is a parameter that
 tells the daq whether or not to save to disk, and ``mode`` is a
 parameter that sets up the ``bluesky`` behavior. See
 `basic usage <./daq_basic>` and

--- a/docs/source/daq_config.rst
+++ b/docs/source/daq_config.rst
@@ -17,5 +17,23 @@ parameter that sets up the ``bluesky`` behavior. See
 `basic usage <./daq_basic>` and
 `using the daq with bluesky <./plans_basic>`.
 
+You can get the current configuration from `Daq.config`.
+Shown here is the default config:
+
+.. ipython:: python
+    :suppress:
+
+    from pcdsdaq.daq import Daq
+    from pcdsdaq.sim import set_sim_mode
+
+    set_sim_mode(True)
+    daq = Daq()
+
+
+.. ipython:: python
+
+    daq.config
+
+
 .. automethod:: pcdsdaq.daq.Daq.configure
    :noindex:

--- a/docs/source/plans_basic.rst
+++ b/docs/source/plans_basic.rst
@@ -1,8 +1,9 @@
 Using the DAQ with Bluesky
 ==========================
-Some utilities are provided for running the daq in sync with a bluesky plan.
-This document will assume some familiarity with ``bluesky`` and how to use the
-``RunEngine``, but does not require a full understanding of the internals.
+Some utilities are provided for running the daq in sync with a ``bluesky``
+``plan``. This document will assume some familiarity with ``bluesky`` and
+how to use the ``RunEngine``, but does not require a full understanding of
+the internals.
 
 I am going to introduce these through a series of examples. You can check the
 full `api docs <./plans_api>` for more information.
@@ -27,7 +28,7 @@ Basic Plan with Daq Support
 ---------------------------
 The simplest way to include the daq is to turn it on at the start of the plan
 and turn it off at the end of the plan. This is done using the default mode,
-``on``, which we'll configure explicitly in the ``daq_wrapper``.
+``on``, which we'll configure explicitly in the `daq_wrapper`.
 
 .. ipython:: python
 
@@ -77,7 +78,7 @@ configured with ``mode='manual'``.
 
 This plan will move ``motor`` from ``start`` to ``end`` in ``steps``
 evenly-spaced steps, checking readings from ``dets`` at each point
-and running a ``calib_cycle`` for ``events_per_point`` events.
+and running a `calib_cycle` for ``events_per_point`` events.
 
 .. ipython:: python
 
@@ -87,7 +88,7 @@ and running a ``calib_cycle`` for ``events_per_point`` events.
 
 Manual Calib Cycle
 ------------------
-You may also call calib_cycle directly:
+You may also call `calib_cycle` directly:
 
 .. ipython:: python
 
@@ -104,7 +105,7 @@ You may also call calib_cycle directly:
         return (yield from inner_daq_count())
 
 
-This plan will run ``calib_cycle`` ``num`` times for ``duration_per_point``
+This plan will run `calib_cycle` ``num`` times for ``duration_per_point``
 seconds each, waiting ``sleep_time`` seconds between cycles.
 
 .. ipython:: python

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -5,7 +5,6 @@ import os
 import time
 import functools
 import threading
-import copy
 import enum
 import logging
 
@@ -608,7 +607,7 @@ class Daq(FlyerInterface):
             when it was last set.
         """
         logger.debug('Daq.read_configuration()')
-        return copy.copy(self._config_ts)
+        return self._config_ts.copy()
 
     def describe_configuration(self):
         """

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -118,9 +118,9 @@ class Daq(FlyerInterface):
         The current configuration, e.g. the last call to `configure`
         """
         if self.configured:
-            return self._config
+            return self._config.copy()
         else:
-            return self.default_config
+            return self.default_config.copy()
 
     @property
     def state(self):

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -83,6 +83,17 @@ def test_configure(daq, sig):
         prev_config = daq.read_configuration()
 
 
+def test_record(daq):
+    """
+    Make sure the record convenience method works.
+    """
+    logger.debug('test_record')
+    daq.record()
+    assert daq.config['record']
+    daq.record(False)
+    assert not daq.config['record']
+
+
 @pytest.mark.timeout(10)
 def test_basic_run(daq, sig):
     """

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -85,13 +85,27 @@ def test_configure(daq, sig):
 
 def test_record(daq):
     """
-    Make sure the record convenience method works.
+    Make sure the record convenience property works.
     """
     logger.debug('test_record')
-    daq.record()
+
+    daq.configure(record=True)
+    assert daq.record
+    daq.configure(record=False)
+    assert not daq.record
+
+    daq.record = True
+    assert daq.record
+    daq.configure()
     assert daq.config['record']
-    daq.record(False)
+    assert daq.record
+
+    daq.record = False
+    assert not daq.record
+    daq.begin()
     assert not daq.config['record']
+    assert not daq.record
+    daq.end_run()
 
 
 @pytest.mark.timeout(10)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add `Daq.record` as a property to schedule a `Daq.configure(record=True)` call later.
- Fix issue where `record` would be reset to `False` after every `configure` where we forget to set it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This makes it so we can enable/disable recording without seeing the output of `Daq.configure` in `ipython`. The fix means we can create plans that ignore the `record` parameter and leave it to the user to set up.