### PR TITLE
FIX: move warning to class instantiation

### DIFF
--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 try:
     import pydaq
 except ImportError:
-    logger.warning('pydaq not in environment. Will not be able to use DAQ!')
+    pydaq = None
 
 # Wait up to this many seconds for daq to be ready for a begin call
 BEGIN_TIMEOUT = 2
@@ -84,6 +84,9 @@ class Daq(FlyerInterface):
     name = 'daq'
 
     def __init__(self, platform=0, RE=None):
+        if pydaq is None:
+            err = 'pydaq not in environment. Will not be able to use DAQ!'
+            logger.warning(err)
         super().__init__()
         self._control = None
         self._config = None

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -7,16 +7,13 @@ import functools
 import threading
 import enum
 import logging
+from importlib import import_module
 
 from ophyd.status import Status, wait as status_wait
 from ophyd.flyers import FlyerInterface
 
 logger = logging.getLogger(__name__)
-
-try:
-    import pydaq
-except ImportError:
-    pydaq = None
+pydaq = None
 
 # Wait up to this many seconds for daq to be ready for a begin call
 BEGIN_TIMEOUT = 2
@@ -85,8 +82,7 @@ class Daq(FlyerInterface):
 
     def __init__(self, platform=0, RE=None):
         if pydaq is None:
-            err = 'pydaq not in environment. Will not be able to use DAQ!'
-            logger.warning(err)
+            globals()['pydaq'] = import_module('pydaq')
         super().__init__()
         self._control = None
         self._config = None

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -257,3 +257,5 @@ def test_call_everything_else(daq, sig):
     daq.configure(controls=dict(sig=sig))
     daq.stage()
     daq.unstage()
+    daq_module.pydaq = None
+    daq_module.Daq()

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -258,4 +258,5 @@ def test_call_everything_else(daq, sig):
     daq.stage()
     daq.unstage()
     daq_module.pydaq = None
-    daq_module.Daq()
+    with pytest.raises(ImportError):
+        daq_module.Daq()


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This warning fires every time we import `daq.py`, even if it's an incidental import that doesn't make a `Daq` object. I think this warning is important, but I don't think it should run on import.

An interesting side effect is that we don't get the warning if we've acknowledged the lack of `pydaq` by setting up the sim daq.