### PR TITLE
ENH: Record in Begin

### DIFF
--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -272,6 +272,10 @@ class Daq(FlyerInterface):
         Begin acquisition. This method is non-blocking.
         See `begin` for a description of the parameters.
 
+        This method does not supply arguments for configuration parameters, it
+        supplies arguments directly to ``pydaq.Control.begin``. It will
+        configure before running if there are queued configuration changes.
+
         This is part of the ``bluesky`` ``Flyer`` interface.
 
         Returns

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -290,8 +290,9 @@ class Daq(FlyerInterface):
             try:
                 self.configure()
             except StateTransitionError:
-                err = 'Illegal reconfigure with {} during an open run'
-                err = err.format(self._desired_config)
+                err = ('Illegal reconfigure with {} during an open run. End '
+                       'the current run with daq.end_run() before running '
+                       'with a new configuration'.format(self._desired_config))
                 logger.debug(err, exc_info=True)
                 raise StateTransitionError(err)
 

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -232,8 +232,8 @@ class Daq(FlyerInterface):
             If ``True``, wait for the daq to finish aquiring data.
         """
         logger.debug(('Daq.begin(events=%s, duration=%s, record=%s, '
-                      'use_l3t=%s, controls=%s, wait=%s)',
-                     events, duration, record, use_l3t, controls, wait))
+                      'use_l3t=%s, controls=%s, wait=%s)'),
+                     events, duration, record, use_l3t, controls, wait)
         if record is not None and record != self.record:
             old_record = self.record
             self.record = record

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -168,7 +168,7 @@ def test_begin_record_arg(daq):
     daq.begin(events=1, wait=True, record=True)
     daq.end_run()
     assert daq.config['record']
-    assert daq._desired_config['record']
+    assert not daq._desired_config
 
     # Same tests, but swap all the booleans
     daq.configure(record=True)
@@ -176,7 +176,7 @@ def test_begin_record_arg(daq):
     daq.begin(events=1, wait=True)
     daq.end_run()
     assert daq.config['record']
-    assert daq._desired_config
+    assert not daq._desired_config
     daq.begin(events=1, wait=True, record=False)
     daq.end_run()
     assert not daq.config['record']
@@ -188,12 +188,12 @@ def test_begin_record_arg(daq):
     daq.begin(events=1, wait=True)
     daq.end_run()
     assert daq.config['record']
-    assert daq._desired_config
+    assert not daq._desired_config
     daq.record = False
     daq.begin(events=1, wait=True, record=False)
     daq.end_run()
     assert not daq.config['record']
-    assert not daq._desired_config['record']
+    assert not daq._desired_config
 
 
 @pytest.mark.timeout(3)

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -145,23 +145,28 @@ def test_begin_record_arg(daq):
     daq.configure(record=False)
     assert not daq.record
     daq.begin(events=1, wait=True)
+    daq.end_run()
     assert not daq.config['record']
     assert not daq._desired_config
     # Did we record?
     daq.begin(events=1, wait=True, record=True)
+    daq.end_run()
     assert daq.config['record']
     assert not daq._desired_config['record']
     # 2 in a row: did we record?
     daq.begin(events=1, wait=True, record=True)
+    daq.end_run()
     assert daq.config['record']
     assert not daq._desired_config['record']
     # Remove record arg: did we not record?
     daq.begin(events=1, wait=True)
+    daq.end_run()
     assert not daq.config['record']
     assert not daq._desired_config
     # Configure for record=True, then also pass to begin
     daq.record = True
     daq.begin(events=1, wait=True, record=True)
+    daq.end_run()
     assert daq.config['record']
     assert daq._desired_config['record']
 
@@ -169,19 +174,24 @@ def test_begin_record_arg(daq):
     daq.configure(record=True)
     assert daq.record
     daq.begin(events=1, wait=True)
+    daq.end_run()
     assert daq.config['record']
     assert daq._desired_config
     daq.begin(events=1, wait=True, record=False)
+    daq.end_run()
     assert not daq.config['record']
     assert daq._desired_config['record']
     daq.begin(events=1, wait=True, record=False)
+    daq.end_run()
     assert not daq.config['record']
     assert daq._desired_config['record']
     daq.begin(events=1, wait=True)
+    daq.end_run()
     assert daq.config['record']
     assert daq._desired_config
     daq.record = False
     daq.begin(events=1, wait=True, record=False)
+    daq.end_run()
     assert not daq.config['record']
     assert not daq._desired_config['record']
 

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -5,7 +5,7 @@ import pytest
 from ophyd.status import wait as status_wait
 
 from pcdsdaq import daq as daq_module
-from pcdsdaq.daq import BEGIN_TIMEOUT
+from pcdsdaq.daq import BEGIN_TIMEOUT, StateTransitionError
 
 logger = logging.getLogger(__name__)
 
@@ -305,8 +305,12 @@ def test_bad_stuff(daq, RE):
 
     # Configure during a run
     daq.begin(duration=1)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(StateTransitionError):
         daq.configure()
+
+    with pytest.raises(StateTransitionError):
+        daq.begin(record=True)
+
     daq.end_run()  # Prevent thread stalling
 
 

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -134,6 +134,58 @@ def test_basic_run(daq, sig):
     assert dt < BEGIN_TIMEOUT + 1
 
 
+@pytest.mark.timeout(10)
+def test_begin_record_arg(daq):
+    """
+    We expect that the record argument in begin overrides the daq's record
+    configuration for the run.
+    """
+    logger.debug('test_begin_record_arg')
+    # Sanity checks
+    daq.configure(record=False)
+    assert not daq.record
+    daq.begin(events=1, wait=True)
+    assert not daq.config['record']
+    assert not daq._desired_config
+    # Did we record?
+    daq.begin(events=1, wait=True, record=True)
+    assert daq.config['record']
+    assert not daq._desired_config['record']
+    # 2 in a row: did we record?
+    daq.begin(events=1, wait=True, record=True)
+    assert daq.config['record']
+    assert not daq._desired_config['record']
+    # Remove record arg: did we not record?
+    daq.begin(events=1, wait=True)
+    assert not daq.config['record']
+    assert not daq._desired_config
+    # Configure for record=True, then also pass to begin
+    daq.record = True
+    daq.begin(events=1, wait=True, record=True)
+    assert daq.config['record']
+    assert daq._desired_config['record']
+
+    # Same tests, but swap all the booleans
+    daq.configure(record=True)
+    assert daq.record
+    daq.begin(events=1, wait=True)
+    assert daq.config['record']
+    assert daq._desired_config
+    daq.begin(events=1, wait=True, record=False)
+    assert not daq.config['record']
+    assert daq._desired_config['record']
+    daq.begin(events=1, wait=True, record=False)
+    assert not daq.config['record']
+    assert daq._desired_config['record']
+    daq.begin(events=1, wait=True)
+    assert daq.config['record']
+    assert daq._desired_config
+    daq.record = False
+    daq.begin(events=1, wait=True, record=False)
+    assert not daq.config['record']
+    assert not daq._desired_config['record']
+
+
 @pytest.mark.timeout(3)
 def test_stop_run(daq):
     """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Allow `daq.begin(record=True)` to temporarily set record to `True` for a run

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Mark Hunter asked for this and it seemed reasonable
closes #15 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passes tests, needs to be verified with real hardware

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added to docstring only, should make a note in the examples too

## Misc
- Will not merge until discussing more, not a bugfix and not urgent
- Need to handle edge case:
```
daq.begin(duration=5, record=True, wait=True)
daq.begin(duration=5, wait=True)
```
This will try to reconfigure back to `record=False` in the middle of an open run, which is not allowed. This should either be stated in the docs or protected for by the class. I might even go as far to say we add a `end_run=True` argument option here... To make it simpler for the user to use `begin` as a one-stop-shop for doing a daq run without a `bluesky` context.