### PR TITLE
ENH: Stop begin(wait=True) on ctrl+c

### DIFF
--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -8,6 +8,7 @@ Features
 --------
 - Add the ``record`` option to the `begin` method. This allows a user running
   interactively to concisely activate recording for single runs.
+- Allow ``ctrl+c`` during a `begin` call with ``wait=True`` to stop the run.
 
 v1.1.0 (2018-03-07)
 ===================

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,6 +1,13 @@
 Release History
 ###############
 
+Next Release
+============
+
+Features
+--------
+- Allow ``ctrl+c`` during a `begin` call with ``wait=True`` to stop the run.
+
 v1.2.0 (2018-05-08)
 ===================
 
@@ -8,7 +15,6 @@ Features
 --------
 - Add the ``record`` option to the `begin` method. This allows a user running
   interactively to concisely activate recording for single runs.
-- Allow ``ctrl+c`` during a `begin` call with ``wait=True`` to stop the run.
 
 v1.1.0 (2018-03-07)
 ===================

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -197,7 +197,9 @@ class Daq(FlyerInterface):
               controls=None, wait=False):
         """
         Start the daq and block until the daq has begun acquiring data.
-        Optionally block until the daq has finished aquiring data.
+
+        Optionally block with ``wait=True`` until the daq has finished aquiring
+        data. If blocking, a ``ctrl+c`` will end the run and clean up.
 
         If omitted, any argument that is shared with `configure`
         will fall back to the configured value.
@@ -229,23 +231,30 @@ class Daq(FlyerInterface):
             must have a ``name`` attribute.
 
         wait: ``bool``, optional
-            If ``True``, wait for the daq to finish aquiring data.
+            If ``True``, wait for the daq to finish aquiring data. A
+            ``KeyboardInterrupt`` (``ctrl+c``) during this wait will end the
+            run and clean up.
         """
         logger.debug(('Daq.begin(events=%s, duration=%s, record=%s, '
                       'use_l3t=%s, controls=%s, wait=%s)'),
                      events, duration, record, use_l3t, controls, wait)
-        if record is not None and record != self.record:
-            old_record = self.record
-            self.record = record
-        begin_status = self.kickoff(events=events, duration=duration,
-                                    use_l3t=use_l3t, controls=controls)
         try:
-            self.record = old_record
-        except NameError:
-            pass
-        status_wait(begin_status, timeout=BEGIN_TIMEOUT)
-        if wait:
-            self.wait()
+            if record is not None and record != self.record:
+                old_record = self.record
+                self.record = record
+            begin_status = self.kickoff(events=events, duration=duration,
+                                        use_l3t=use_l3t, controls=controls)
+            status_wait(begin_status, timeout=BEGIN_TIMEOUT)
+            if wait:
+                self.wait()
+        except KeyboardInterrupt:
+            self.end_run()
+            logger.info('%s.begin interrupted, ending run', self.name)
+        finally:
+            try:
+                self.record = old_record
+            except NameError:
+                pass
 
     @check_connect
     def stop(self):

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -1,5 +1,8 @@
-import time
 import logging
+import os
+import signal
+import time
+from threading import Thread
 
 import pytest
 from ophyd.status import wait as status_wait
@@ -326,3 +329,17 @@ def test_call_everything_else(daq, sig):
     daq_module.pydaq = None
     with pytest.raises(ImportError):
         daq_module.Daq()
+
+
+def test_begin_sigint(daq):
+    logger.debug('test_begin_sigint')
+    pid = os.getpid()
+
+    def interrupt():
+        time.sleep(0.1)
+        os.kill(pid, signal.SIGINT)
+
+    start = time.time()
+    Thread(target=interrupt, args=()).start()
+    daq.begin(duration=1, wait=True)
+    assert time.time() - start < 0.5


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
A user can escape `daq.begin(wait=True)` using `ctrl+c`, which will stop the run.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, this did not stop the run, which caused confusion because the run was still going and another run could not be started.

closes #20 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests and tested in `sxr`

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Edited docstrings and added to release notes.

<!--
## Screenshots (if appropriate):
-->
