### PR TITLE
ENH: QOL improvements from the flight back

### DIFF
--- a/docs/source/daq_basic.rst
+++ b/docs/source/daq_basic.rst
@@ -39,7 +39,7 @@ First, I will set up the `Daq` class in simulated mode. In practice, the
     from pcdsdaq.sim import set_sim_mode
 
     set_sim_mode(True)
-    daq = Daq(platform=4)  # Defined per hutch
+    daq = Daq()
 
 
 .. ipython:: python
@@ -50,13 +50,15 @@ First, I will set up the `Daq` class in simulated mode. In practice, the
     from pcdsdaq.sim import set_sim_mode
 
     set_sim_mode(True)
-    daq = Daq(platform=4)  # Defined per hutch
+    daq = Daq()
 
 
 Running Until Stop
 ------------------
 Calling `Daq.begin` with no arguments in the default configuration will
 run the daq indefinitely, until we manually stop it.
+You can also use `Daq.begin_infinite` to run the daq indefinitely with
+any configuration.
 Here I check `Daq.state` to verify that we've started running the daq.
 
 .. ipython:: python
@@ -105,6 +107,19 @@ We can pass ``wait=True`` to skip the `Daq.wait` call.
     print(time.time() - start)
     daq.state
     daq.end_run()
+    daq.state
+
+
+Ending a Run
+------------
+As seen in the previous examples, `Daq.end_run` can be used to tell the daq
+that the current run is over. You can also do with with an argument to
+`Daq.begin` for a nice one-liner:
+
+.. ipython:: python
+
+    daq.state
+    daq.begin(duration=1, wait=True, end_run=True)
     daq.state
 
 

--- a/docs/source/daq_config.rst
+++ b/docs/source/daq_config.rst
@@ -3,15 +3,9 @@ Configuration
 Some manual configuration is necessary to record data or to run
 special ``bluesky`` plans with daq support.
 
-In general, there are two kinds of `Daq.configure` arguments:
-those that are shared with `Daq.begin`, and those that are not.
-
-Arguments that are shared between the two methods act as defaults.
-For example, calling ``daq.configure(duration=3)`` will set the
-no-arguments behavior of ``daq.begin()`` to run the daq for 3 seconds.
-
 You can get the current configuration from `Daq.config`.
 Shown here is the default config:
+
 
 .. ipython:: python
     :suppress:
@@ -26,6 +20,22 @@ Shown here is the default config:
 .. ipython:: python
 
     daq.config
+
+You can also print this information nicely using `Daq.config_info`.
+
+You can configure the daq through `Daq.configure`, which configures
+the daq right away, or `Daq.preconfig`, which schedules a configuration
+to be done when it is next needed. This distinction is sometimes important
+because we cannot do a full configure during an open run, for example.
+As an aside, `Daq.configure` has a long return value, which may make
+`Daq.preconfig` the preferred method for interactive sessions.
+
+In general, there are two kinds of configuration arguments:
+those that are shared with `Daq.begin`, and those that are not.
+
+Arguments that are shared between the two methods act as defaults.
+For example, calling ``daq.configure(duration=3)`` will set the
+no-arguments behavior of ``daq.begin()`` to run the daq for 3 seconds.
 
 
 .. automethod:: pcdsdaq.daq.Daq.configure

--- a/docs/source/plans_basic.rst
+++ b/docs/source/plans_basic.rst
@@ -122,3 +122,11 @@ and back to the ``start`` positions, and then end the run.
 If you ignore the `daq_during_decorator`, this is just a normal ``plan``.
 This makes it simple to add the daq collecting data in the background
 to a normal ``bluesky`` ``plan``.
+
+
+After the Plan
+--------------
+The daq will automatically be returned to whatever state it was in before
+running the ``bluesky`` ``plan``. This means if you start from a disconnected
+state, we will disconnect, if you start from a running state we will return
+to running, and if you start from a configured state we'll stay connected.

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -1,8 +1,8 @@
 Release History
 ###############
 
-Next Release
-============
+v2.0.0 (2018-05-27)
+===================
 
 Features
 --------
@@ -15,6 +15,12 @@ Features
   A calibcycle will be run when the `Daq` is triggered, and triggering will be
   reported as done when the `Daq` has stopped. This means it is viable to use
   the `Daq` inside normal plans like ``scan`` and ``count``.
+- Add an argument to `Daq.begin`: ``end_run=True`` will end the run once the
+  daq stops running, rather than leaving the run open.
+- Add `Daq.begin_infinite`
+- Add `Daq.config_info`
+- Restore daq state after a ``bluesky`` ``plan``, e.g. disconnect if we were
+  disconnected, run if we were running, etc.
 
 API Changes
 -----------

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -838,7 +838,7 @@ class Daq:
         if self._pre_run_state == 'Disconnected':
             self.disconnect()
         elif self._pre_run_state == 'Running':
-            self.begin(events=0, record=False, use_l3t=False)
+            self.begin_infinite()
         # For other states, end_run was sufficient.
         return [self]
 

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -196,6 +196,7 @@ class Daq:
             self._control.disconnect()
         del self._control
         self._control = None
+        self._desired_config = self._config
         self._config = None
         logger.info('DAQ is disconnected.')
 

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -273,7 +273,9 @@ class Daq:
             status_wait(begin_status, timeout=BEGIN_TIMEOUT)
             if wait:
                 self.wait()
-            if end_run:
+                if end_run:
+                    self.end_run()
+            if end_run and not wait:
                 threading.Thread(target=self._ender_thread, args=()).start()
         except KeyboardInterrupt:
             self.end_run()

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -193,6 +193,7 @@ class Daq:
         """
         logger.debug('Daq.disconnect()')
         if self._control is not None:
+            self.end_run()
             self._control.disconnect()
         del self._control
         self._control = None
@@ -216,7 +217,7 @@ class Daq:
             status_wait(status, timeout=timeout)
 
     def begin(self, events=None, duration=None, record=None, use_l3t=None,
-              controls=None, wait=False):
+              controls=None, wait=False, end_run=False):
         """
         Start the daq and block until the daq has begun acquiring data.
 
@@ -256,6 +257,9 @@ class Daq:
             If ``True``, wait for the daq to finish aquiring data. A
             ``KeyboardInterrupt`` (``ctrl+c``) during this wait will end the
             run and clean up.
+
+        end_run: ``bool``, optional
+            If ``True``, we'll end the run after the daq has stopped.
         """
         logger.debug(('Daq.begin(events=%s, duration=%s, record=%s, '
                       'use_l3t=%s, controls=%s, wait=%s)'),
@@ -263,20 +267,36 @@ class Daq:
         try:
             if record is not None and record != self.record:
                 old_record = self.record
-                self.record = record
+                self.preconfig(record=record, show_queued_cfg=False)
             begin_status = self.kickoff(events=events, duration=duration,
                                         use_l3t=use_l3t, controls=controls)
             status_wait(begin_status, timeout=BEGIN_TIMEOUT)
             if wait:
                 self.wait()
+            if end_run:
+                threading.Thread(target=self._ender_thread, args=()).start()
         except KeyboardInterrupt:
             self.end_run()
             logger.info('%s.begin interrupted, ending run', self.name)
         finally:
             try:
-                self.record = old_record
+                self.preconfig(record=old_record, show_queued_cfg=False)
             except NameError:
                 pass
+
+    def begin_infinite(self, record=None, use_l3t=None, controls=None):
+        """
+        Start the daq to run forever in the background.
+        """
+        self.begin(events=0, record=record, use_l3t=use_l3t,
+                   controls=controls, wait=False, end_run=False)
+
+    def _ender_thread(self):
+        """
+        End the run when the daq stops aquiring
+        """
+        self.wait()
+        self.end_run()
 
     @check_connect
     def stop(self):
@@ -474,18 +494,21 @@ class Daq:
         This will display the next queued configuration using logger.info,
         assuming the logger has been configured.
         """
-        for arg, name in zip((events, duration, record, use_l3t, controls),
-                             ('events', 'duration', 'record', 'use_l3t',
-                              'controls')):
+        # Only one of (events, duration) should be preconfigured.
+        if events is not None:
+            self._desired_config['events'] = events
+            self._desired_config['duration'] = None
+        elif duration is not None:
+            self._desired_config['events'] = None
+            self._desired_config['duration'] = duration
+
+        for arg, name in zip((record, use_l3t, controls),
+                             ('record', 'use_l3t', 'controls')):
             if arg is not None:
                 self._desired_config[name] = arg
 
         if show_queued_cfg:
-            txt = 'The following config is queued:\n'
-            for key, value in self.next_config.items():
-                if value is not None:
-                    txt.append('{}: {}\n'.format(key, value))
-            logger.info(txt)
+            self.config_info(self.next_config, 'Queued config:')
 
     @check_connect
     def configure(self, events=None, duration=None, record=None,
@@ -547,13 +570,18 @@ class Daq:
         self.preconfig(events=events, duration=duration, record=record,
                        use_l3t=use_l3t, controls=controls,
                        show_queued_cfg=False)
-        config = self.next_config()
+        config = self.next_config
 
         events = config['events']
         duration = config['duration']
         record = config['record']
         use_l3t = config['use_l3t']
         controls = config['controls']
+
+        logger.debug(('Updated with queued config, now we have: '
+                      'events=%s, duration=%s, record=%s, '
+                      'use_l3t=%s, controls=%s'),
+                     events, duration, record, use_l3t, controls)
 
         config_args = self._config_args(record, use_l3t, controls)
         try:
@@ -566,8 +594,7 @@ class Daq:
                                 record=record, use_l3t=use_l3t,
                                 controls=controls)
             self._update_config_ts()
-            msg = 'Daq configured'
-            logger.info(msg)
+            self.config_info(header='Daq configured:')
         except Exception as exc:
             self._config = None
             msg = 'Failed to configure!'
@@ -576,6 +603,32 @@ class Daq:
         new = self.read_configuration()
         self._desired_config = {}
         return old, new
+
+    def config_info(self, config=None, header='Config:'):
+        """
+        Show the config information as a logger.info message.
+
+        This will print to the screen if the logger is configured correctly.
+
+        Parameters
+        ----------
+        config: ``dict``, optional
+            The configuration to show. If omitted, we'll use the current
+            config.
+
+        header: ``str``, optional
+            A prefix for the config line.
+        """
+        if config is None:
+            config = self.config
+
+        txt = []
+        for key, value in config.items():
+            if value is not None:
+                txt.append('{}={}'.format(key, value))
+        if header:
+            header += ' '
+        logger.info(header + ', '.join(txt))
 
     @property
     def record(self):
@@ -743,6 +796,8 @@ class Daq:
         This sets up the daq to end runs on run stop documents.
         It also caches the current state, so we know what state to return to
         after the ``bluesky`` scan.
+        If a run is already started, we'll end it here so that we can start a
+        new run during the scan.
 
         Returns
         -------
@@ -753,6 +808,7 @@ class Daq:
         self._pre_run_state = self.state
         if self._re_cbid is None:
             self._re_cbid = self._RE.subscribe(self._re_manage_runs)
+        self.end_run()
         return [self]
 
     def _re_manage_runs(self, name, doc):
@@ -829,8 +885,6 @@ class Daq:
 
     def __del__(self):
         try:
-            if self.state in ('Open', 'Running'):
-                self.end_run()
             self.disconnect()
         except Exception:
             pass

--- a/pcdsdaq/sim/pydaq.py
+++ b/pcdsdaq/sim/pydaq.py
@@ -151,6 +151,7 @@ class Control:
     def _begin_thread(self, duration):
         logger.debug('SimControl._begin_thread(%s)', duration)
         start = time.time()
+        initial_duration = duration
         interrupted = False
         dt = 0.1
         while duration > 0:
@@ -165,7 +166,7 @@ class Control:
                 pass
         end = time.time()
         logger.debug('%ss elapsed in SimControl._begin_thread(%s)',
-                     end-start, duration)
+                     end-start, initial_duration)
 
     def end(self):
         logger.debug('SimControl.end()')

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -100,6 +100,14 @@ def test_configure(daq, sig):
         prev_config = daq.read_configuration()
 
 
+def test_disconnect_config(daq):
+    logger.debug('test_disconnect_config')
+
+    daq.configure(events=120)
+    daq.disconnect()
+    assert daq.next_config['events'] == 120
+
+
 def test_record(daq):
     """
     Make sure the record convenience property works.
@@ -342,6 +350,23 @@ def test_trigger_error(daq, RE):
     daq.configure(events=None, duration=None)
     with pytest.raises(RuntimeError):
         daq.trigger()
+
+
+def test_preconfig(daq):
+    logger.debug('test_preconfig')
+
+    daq.preconfig(events=120, use_l3t=True)
+    assert daq.state == 'Disconnected'
+    daq.configure()
+    assert daq.config['events'] == 120
+    assert daq.config['use_l3t']
+
+    daq.preconfig(events=240, use_l3t=True)
+    daq.preconfig(duration=1)
+    daq.configure(use_l3t=False)
+    assert daq.config['events'] is None
+    assert daq.config['duration'] == 1
+    assert not daq.config['use_l3t']
 
 
 def test_restore_state(daq, RE):

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -141,6 +141,19 @@ def test_basic_run(daq, sig):
     daq.end_run()
     assert daq.state == 'Configured'
     daq.begin(events=1, wait=True, use_l3t=True)
+    daq.end_run()
+    # Configure for 1 event, if takes less than 1s then inf broken
+    daq.configure(events=1)
+    daq.begin_infinite()
+    time.sleep(1)
+    assert daq.state == 'Running'
+    daq.end_run()
+    daq.begin(events=1, wait=True, end_run=True)
+    assert daq.state == 'Configured'
+    daq.begin(events=1, wait=False, end_run=True)
+    time.sleep(0.2)
+    assert daq.state == 'Configured'
+
     # now we force the kickoff to time out
     daq._control._state = 'Disconnected'
     start = time.time()
@@ -329,6 +342,21 @@ def test_trigger_error(daq, RE):
     daq.configure(events=None, duration=None)
     with pytest.raises(RuntimeError):
         daq.trigger()
+
+
+def test_restore_state(daq, RE):
+    logger.debug('test_restore_state')
+
+    assert daq.state == 'Disconnected'
+    daq.preconfig(events=1)
+    RE(count([daq]))
+    assert daq.state == 'Disconnected'
+
+    daq.begin_infinite()
+    assert daq.state == 'Running'
+    RE(count([daq]))
+    assert daq.state == 'Running'
+    daq.end_run()
 
 
 def test_bad_stuff(daq, RE):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Mishmash of ideas I implemented on the plane, not quite ready to merge but good for discussion:

- Resume previous state after a bluesky run via `stage` and `unstage` (idea: should this be put on `begin` as well?). This means that if we were disconnected, we disconnect after a run, if we were running we start an infinite run (with record forced to `False`), etc.
- Queue up configurations without executing them via `preconfig`. This makes it possible to take advantage of the previous point from a disconnected state. This also allows the user to avoid seeing the giant return `dict` from `configure` that people will find annoying.
- `begin_infinite` helper function to run the `daq` forever. It was tough to manually do this after a configure without special knowledge, so this helps you set it up so that the state resumer will put the daq back into running mode.
- `end_run` convenience kwarg on `begin` to end the run after the duration has expired

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- quality of life, etc.
- closes #29 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Lines covered, needs field testing

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docs need updating

<!--
## Screenshots (if appropriate):
-->
