### PR TITLE
ENH: Run number

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,6 +24,7 @@
    :hidden:
 
    scan_pvs.rst
+   misc.rst
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/misc.rst
+++ b/docs/source/misc.rst
@@ -1,0 +1,26 @@
+=============
+Miscellaneous
+=============
+
+This page will show off some features that are not big enough to warrant their
+own page.
+
+.. ipython:: python
+   :suppress:
+
+   from pcdsdaq.daq import Daq
+   from pcdsdaq.sim import set_sim_mode
+
+   set_sim_mode(True)
+   daq = Daq()
+
+Run Number
+----------
+
+Call `Daq.run_number` to get the current run number. This will either be the
+run number of the last run if we are not recording, or the current run if
+we are.
+
+.. ipython:: python
+
+   run_num = daq.run_number()

--- a/docs/source/releases.rst
+++ b/docs/source/releases.rst
@@ -7,8 +7,8 @@ v2.0.0 (2018-05-27)
 Features
 --------
 - Allow ``ctrl+c`` during a `begin` call with ``wait=True`` to stop the run.
-- Add sourcable `pcdsdaq_lib_setup` script that will get `pydaq` and `pycdb`
-  ready for your python environment.
+- Add sourcable ``pcdsdaq_lib_setup`` script that will get ``pydaq`` and
+  ``pycdb`` ready for your python environment.
 - The `connect` method will provide more helpful error messages when it fails.
 - Allow the `Daq` class to be used as a ``bluesky`` readable device.
   Once staged, runs will end on run stop documents.

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -895,11 +895,12 @@ class Daq:
         """
         Determine the run number of the last run, or current run if running.
 
-        This requires you to be on an NFS-mounted host. If hutch is
-        unambiguous, it doesn't need to be passed in.
+        This requires you to be on an NFS-mounted host. If hutch can be
+        determined from the get_hutch_name script from engineering_tools, then
+        you don't need to pass in a hutch name.
 
         This is a method and not a property because all properties are
-        ran when you try to tab complete, and this isn't necessarily an
+        run when you try to tab complete, and this isn't necessarily an
         instant check. It can also display log messages, which would be
         annoying on tab complete.
 

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -401,6 +401,9 @@ class Daq:
             if self.state in ('Configured', 'Open'):
                 begin_args = self._begin_args(events, duration, use_l3t,
                                               controls)
+                if self.record:
+                    next_run = self.run_number() + 1
+                    logger.info('Beginning daq run %s', next_run)
                 logger.debug('daq.control.begin(%s)', begin_args)
                 control.begin(**begin_args)
                 # Cache these so we know what the most recent begin was told

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -402,8 +402,10 @@ class Daq:
                 begin_args = self._begin_args(events, duration, use_l3t,
                                               controls)
                 if self.record:
-                    next_run = self.run_number() + 1
-                    logger.info('Beginning daq run %s', next_run)
+                    prev_run = self.run_number()
+                    if prev_run is not None:
+                        next_run = self.run_number() + 1
+                        logger.info('Beginning daq run %s', next_run)
                 logger.debug('daq.control.begin(%s)', begin_args)
                 control.begin(**begin_args)
                 # Cache these so we know what the most recent begin was told
@@ -929,7 +931,7 @@ class Daq:
             return None
         get_run = scripts.format(hutch_name, 'get_lastRun')
         args = [get_run, '-i', hutch_name]
-        if self.state in ('Open', 'Running') and self.record:
+        if self.state in ('Open', 'Running') and self.config['record']:
             run_number = subprocess.check_output(args + ['l'],
                                                  universal_newlines=True)
         else:

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -401,7 +401,7 @@ class Daq:
             if self.state in ('Configured', 'Open'):
                 begin_args = self._begin_args(events, duration, use_l3t,
                                               controls)
-                if self.record:
+                if self.config['record']:
                     prev_run = self.run_number()
                     if prev_run is not None:
                         next_run = self.run_number() + 1

--- a/pcdsdaq/ext_scripts.py
+++ b/pcdsdaq/ext_scripts.py
@@ -1,0 +1,33 @@
+import logging
+import subprocess
+
+
+logger = logging.getLogger(__name__)
+SCRIPTS = '/reg/g/pcds/engineering_tools/{}/scripts/{}'
+
+
+def call_script(args):
+    logger.debug('Calling external script %s', args)
+    try:
+        return subprocess.check_output(args, universal_newlines=True)
+    except Exception:
+        logger.debug('Exception raised from %s', args, exc_info=True)
+        raise
+
+
+def hutch_name():
+    script = SCRIPTS.format('latest', 'get_hutch_name')
+    name = call_script(script)
+    return name.lower().strip(' \n')
+
+
+def get_run_number(hutch=None, live=False):
+    latest = hutch or 'latest'
+    script = SCRIPTS.format(latest, 'get_lastRun')
+    args = [script]
+    if hutch is not None:
+        args += ['-i', hutch]
+    if live:
+        args += ['-l']
+    run_number = call_script(args)
+    return int(run_number)

--- a/pcdsdaq/sim/__init__.py
+++ b/pcdsdaq/sim/__init__.py
@@ -2,10 +2,14 @@
 This module provides a simulated pydaq module for offline testing and training.
 It does not assume that the real pydaq module is available.
 """
+import logging
 from importlib import import_module
 
 import pcdsdaq.daq as daq
+import pcdsdaq.ext_scripts as ext
 from . import pydaq
+
+logger = logging.getLogger(__name__)
 
 
 def set_sim_mode(sim_mode):
@@ -18,6 +22,13 @@ def set_sim_mode(sim_mode):
     """
     if sim_mode:
         daq.pydaq = pydaq
+        ext.hutch_name = pydaq.sim_hutch_name
+        ext.get_run_number = pydaq.sim_get_run_number
     else:
-        real_pydaq = import_module('pydaq')
-        daq.pydaq = real_pydaq
+        try:
+            real_pydaq = import_module('pydaq')
+            daq.pydaq = real_pydaq
+        except ImportError:
+            logger.error('pydaq not available in this session')
+        ext.hutch_name = pydaq.hutch_name
+        ext.get_run_number = pydaq.get_run_number

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,11 @@ def nodaq(RE):
 
 
 @pytest.fixture(scope='function')
+def nosim():
+    set_sim_mode(False)
+
+
+@pytest.fixture(scope='function')
 def RE():
     RE = RunEngine({})
     RE.verbose = True

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -471,7 +471,8 @@ def test_run_number(daq, monkeypatch):
 
     # Simulate not being on nfs
     monkeypatch.setattr(os.path, 'exists', lambda x: False)
-    assert daq.run_number() is None
+    with pytest.raises(RuntimeError):
+        daq.run_number()
 
     # Check the success states
     monkeypatch.setattr(os.path, 'exists', lambda x: True)
@@ -488,4 +489,5 @@ def test_run_number(daq, monkeypatch):
     daq.end_run()
 
     # Bad hutch name
-    assert daq.run_number('bad_hutch_name') is None
+    with pytest.raises(ValueError):
+        daq.run_number('bad_hutch_name')

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -469,6 +469,11 @@ def test_run_number(daq, monkeypatch):
     daq.begin(record=True, events=1, wait=True, end_run=True)
     assert daq.run_number() == start_num + 1
 
+    # Get during a run to text other branch
+    daq.begin(record=True, events=1000)
+    assert daq.run_number() == start_num + 2
+    daq.end_run()
+
     # Make sure correct exceptions are raised
     with pytest.raises(ValueError):
         assert daq.run_number('not_a_hutch')
@@ -480,3 +485,8 @@ def test_run_number(daq, monkeypatch):
 
     with pytest.raises(RuntimeError):
         daq.run_number()
+
+    # We shouldn't have an exception in begin if run_number fails!
+    # Not important enough to hold up the show
+    daq.begin(events=100, record=True)
+    daq.end_run()

--- a/tests/test_ext_scripts.py
+++ b/tests/test_ext_scripts.py
@@ -1,0 +1,34 @@
+import logging
+
+import pytest
+
+import pcdsdaq.ext_scripts as ext
+
+logger = logging.getLogger(__name__)
+
+
+def test_call_script():
+    logger.debug('test_call_script')
+    assert isinstance(ext.call_script('uname'), str)
+    with pytest.raises(FileNotFoundError):
+        ext.call_script('definitelynotarealscriptgeezman')
+
+
+def test_hutch_name(nosim, monkeypatch):
+    logger.debug('test_hutch_name')
+
+    def fake_hutch_name(*args, **kwargs):
+        return 'tst\n'
+
+    monkeypatch.setattr(ext, 'call_script', fake_hutch_name)
+    assert ext.hutch_name() == 'tst'
+
+
+def test_run_number(nosim, monkeypatch):
+    logger.debug('test_run_number')
+
+    def fake_run_number(*args, **kwargs):
+        return '1\n'
+
+    monkeypatch.setattr(ext, 'call_script', fake_run_number)
+    assert ext.get_run_number(hutch='tst', live=True) == 1

--- a/tests/test_scan_vars.py
+++ b/tests/test_scan_vars.py
@@ -7,6 +7,7 @@ from bluesky.preprocessors import run_wrapper, stage_wrapper
 from ophyd.signal import Signal
 from ophyd.sim import motor, motor1, motor2, motor3, det1, det2
 
+import pcdsdaq.daq
 from pcdsdaq.scan_vars import ScanVars
 
 logger = logging.getLogger(__name__)
@@ -82,3 +83,12 @@ def test_scan_vars(RE, daq):
     # Last, let's force an otherwise uncaught error to cover the catch-all
     # try-except block to make sure the log message doesn't error
     scan_vars.start({'motors': 4})
+
+
+def test_scan_vars_no_daq(RE):
+    logger.debug('test_scan_vars_no_daq')
+
+    # If no daq has ever been loaded, we should cover an extra line
+    pcdsdaq.daq._daq_instance = None
+    scan_vars = ScanVars('TST', name='tst', RE=RE)
+    scan_vars.start({})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
`daq.run_number()` gives the run number. It uses the `engineering_tools` scripts to accomplish this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `pydaq` run number utilities are only valid if we just did a run. These scripts use regdb to get the real run number. I did not want to open the can of worms of getting regdb into our environment, though it may not have been hard.

closes #22 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've added tests and I've done some live testing.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
I added a `misc.rst` page to the docs.

<!--
## Screenshots (if appropriate):
-->
