### PR TITLE
FIX: attempt to fix unlink reinstall bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Test conda build
-  - conda build -q conda-recipe --output-folder bld-dir
+  - conda build -q conda-recipe --python $TRAVIS_PYTHON_VERSION --output-folder bld-dir
   - conda config --add channels "file://`pwd`/bld-dir"
   # Create test environment
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pcdsdaq --file dev-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ install:
   # Create test environment
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pcdsdaq --file dev-requirements.txt
   - source activate test-environment
+  # Test uninstall, reinstall linker scripts
+  - conda uninstall pcdsdaq
+  - conda install pcdsdaq
 
 script:
   - coverage run run_tests.py

--- a/conda-recipe/pre-unlink.sh
+++ b/conda-recipe/pre-unlink.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "${PREFIX}/lib/python3.6/site-packages/pcdsdaq/pydaq_links"
+./unlinker

--- a/pcdsdaq/pydaq_links/unlinker
+++ b/pcdsdaq/pydaq_links/unlinker
@@ -1,0 +1,1 @@
+rm -rf links


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a `pre-unlink` script to the conda recipe

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`conda install pcdsdaq=<newer_version>` fails because I have a post-link script but no pre-unlink script

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Sort of tested in the travis I think? Looking for suggestions