### PR TITLE
ENH: Allow daq to be used in "run until other things are done" mode

### DIFF
--- a/docs/source/plans_basic.rst
+++ b/docs/source/plans_basic.rst
@@ -13,6 +13,7 @@ Creating a Daq object with the RunEngine
 ----------------------------------------
 The `Daq` needs to register a ``RunEngine`` instance for this to work. This
 must be the same ``RunEngine`` that will be running all of the plans.
+This will be done automatically for you in a ``hutch-python`` session.
 
 .. code-block:: python
 
@@ -43,7 +44,7 @@ must be the same ``RunEngine`` that will be running all of the plans.
 
    The ``daq`` object must be staged if it's going to be used in a plan. This
    is done automatically in `daq_during_wrapper`, `daq_during_decorator`, and
-   most built-ins like ``count`` and ``scan``.
+   in most built-in plans like ``count`` and ``scan``.
 
 
 Calib Cycles
@@ -73,6 +74,28 @@ step.
 .. ipython:: python
 
     RE(scan([daq], motor1, 0, 10, 11))
+
+
+Running with the Sequencer
+--------------------------
+If the daq or the sequencer is configured to run forever, and the other is
+configured for a fixed duration or number of events, you can use a normal
+daq/sequencer procedure. Each of these devices will wait for the other to
+complete when used in a scan in this way.
+
+If the daq is configured to run forever, and the event sequencer has a fixed
+run, then we will be executing an event sequencer-controlled plan. At each scan
+step, we will start the daq, start the sequencer, wait for the sequencer, and
+stop the daq.
+
+If the sequencer is configured to run forever and the daq has a fixed run, then
+we will be executing a daq-controlled plan. At each scan step, we will start
+the daq, start the sequencer, wait for the daq, and let the sequencer go until
+restarting at the next scan step.
+
+.. code-block:: python
+
+    RE(scan([daq, sequencer], motor, 0, 10, 11))
 
 
 Running for an Entire Plan Duration

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,13 @@ import pytest
 def daq(RE):
     set_sim_mode(True)
     sim_pydaq.conn_err = None
-    return Daq(RE=RE, platform=0)
+    daq = Daq(RE=RE, platform=0)
+    yield daq
+    try:
+        # Sim daq can freeze pytest's exit if we don't end the run
+        daq.end_run()
+    except Exception:
+        pass
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Some changes that make it easy to run the daq "forever" while waiting for everything else to complete e.g. the sequencer, some slow detectors, some averaging things, etc.

Usage would be something like `yield from configure(daq, events=0), yield from scan([daq, ...], ...)`

- Switch wait to throw an error when daq is set to run forever as a safeguard
- Clarify the trigger error is for an unconfigured daq, rather than an infinitely-configured daq
- Stop on the read
- If configured to run forever, then `_get_end_status` returns a finished status immediately

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When you have the daq and the sequencer together in a scan it does something like:
- `daq.trigger()`
- `seq.trigger()`
- wait for everything to be done
- `daq.read()`
- `seq.read()`

So if daq's trigger status returns done immediately we only wait for the sequencer, then we end the calib cycle at the read call. It seemed like the easiest way to implement the behaviour we wanted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Added docs

<!--
## Screenshots (if appropriate):
-->
