### PR TITLE
WIP: Add rudimentary plan to configure DAQ and EventSequencer

### DIFF
--- a/pcdsdaq/plans.py
+++ b/pcdsdaq/plans.py
@@ -1,0 +1,19 @@
+"""
+Plans relevant to running the DAQ in coordination with other specialized
+beamline equipment relevant to run control
+"""
+import bluesky.plan_stubs as bps
+
+
+def sequencer_mode(daq, sequencer, iterations):
+    """
+    Configure the DAQ to be controlled by the EventSequencer
+    """
+    # Configure the DAQ to be run-forever. It will be run by the EventSequencer
+    yield from bps.configure(daq, events=0)
+    # Configure the EventSequencer to run for a specified number of sequences
+    yield from bps.configure(sequencer, play_mode=1, rep_count=iterations)
+    # TODO: It would be nice to add additional checks here to ensure that our
+    # configuration is reasonable
+    # * Is the DAQ configured to readout on an event code?
+    # * Does the Sequencer have the DAQ's readout event code in its' sequence?

--- a/pcdsdaq/plans.py
+++ b/pcdsdaq/plans.py
@@ -5,7 +5,7 @@ beamline equipment relevant to run control
 import bluesky.plan_stubs as bps
 
 
-def sequencer_mode(daq, sequencer, iterations):
+def sequencer_mode(daq, sequencer, iterations, sequence_wait=250):
     """
     Configure the DAQ to be controlled by the EventSequencer
     """
@@ -13,6 +13,8 @@ def sequencer_mode(daq, sequencer, iterations):
     yield from bps.configure(daq, events=0)
     # Configure the EventSequencer to run for a specified number of sequences
     yield from bps.configure(sequencer, play_mode=1, rep_count=iterations)
+    # Configure the EventSequencer to wait for the DAQ to arm itself
+    sequencer.DEFAULT_SLEEP = sequence_wait
     # TODO: It would be nice to add additional checks here to ensure that our
     # configuration is reasonable
     # * Is the DAQ configured to readout on an event code?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Basic plan to configure the `DAQ` to run forever and an `EventSequencer` to run for a set number of iterations.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow for configuration of both devices so that they work nicely with default `bluesky.plans`:
```python
def my_scan(...):
    yield from sequence_mode(daq, sequencer, 25)
    yield from scan([daq, sequencer], ...)
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
WIP
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
WIP

