### PR TITLE
FIX: Rapid cycle bug

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - ophyd >=1.1.0
     - bluesky >=1.2.0
     - toolz
+    - matplotlib <3
 
 test:
   imports:

--- a/docs/source/daq_basic.rst
+++ b/docs/source/daq_basic.rst
@@ -164,3 +164,9 @@ Advanced Options
                     until the configured sleep time elapses. This may be
                     useful if you have other devices that rely on a run to
                     actually start before doing some action.
+- ``stop_sleep=0.5``: This configuration arguments is the same as
+                    ``begin_sleep``, but for the ``stop`` call. This is useful
+                    for very rapid scans that progress too quickly for the daq
+                    transitions to keep up. If you have a slow scan, feel free
+                    to zero this out: the default is ``1`` to prevent scan
+                    crashes with fast scans using default settings.

--- a/docs/source/daq_basic.rst
+++ b/docs/source/daq_basic.rst
@@ -164,9 +164,3 @@ Advanced Options
                     until the configured sleep time elapses. This may be
                     useful if you have other devices that rely on a run to
                     actually start before doing some action.
-- ``stop_sleep=0.5``: This configuration arguments is the same as
-                    ``begin_sleep``, but for the ``stop`` call. This is useful
-                    for very rapid scans that progress too quickly for the daq
-                    transitions to keep up. If you have a slow scan, feel free
-                    to zero this out: the default is ``1`` to prevent scan
-                    crashes with fast scans using default settings.

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -204,7 +204,7 @@ class Daq:
             self._control.disconnect()
         del self._control
         self._control = None
-        self._desired_config = {}
+        self._desired_config = self._config or {}
         self._config = None
         logger.info('DAQ is disconnected.')
 

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -7,7 +7,6 @@ import logging
 import os
 import time
 import threading
-import warnings
 from importlib import import_module
 
 from ophyd.status import Status, wait as status_wait
@@ -79,14 +78,10 @@ class Daq:
     name = 'daq'
     parent = None
 
-    def __init__(self, platform=None, RE=None):
+    def __init__(self, RE=None):
         if pydaq is None:
             globals()['pydaq'] = import_module('pydaq')
         super().__init__()
-        if platform is not None:
-            warnings.warn(('platform argument for daq class is deprecated '
-                           'and will be removed in a future release'),
-                          DeprecationWarning)
         self._control = None
         self._config = None
         self._desired_config = {}

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -201,7 +201,7 @@ class Daq:
             self._control.disconnect()
         del self._control
         self._control = None
-        self._desired_config = self._config
+        self._desired_config = {}
         self._config = None
         logger.info('DAQ is disconnected.')
 

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -418,7 +418,6 @@ class Daq:
             # Stop and start if we already started
             if self.state in ('Open', 'Running'):
                 self.stop()
-                self.wait()
             # It can take up to 0.4s after a previous begin to be ready
             while tmo > 0:
                 if self.state in ('Configured', 'Open'):

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -20,6 +20,8 @@ pydaq = None
 
 # Wait up to this many seconds for daq to be ready for a begin call
 BEGIN_TIMEOUT = 2
+# Do not allow begins within this many seconds of a stop
+BEGIN_THROTTLE = 1
 
 
 def check_connect(f):
@@ -73,8 +75,7 @@ class Daq:
                           use_l3t=False,
                           record=False,
                           controls=None,
-                          begin_sleep=0,
-                          stop_sleep=1)
+                          begin_sleep=0)
     name = 'daq'
     parent = None
 
@@ -302,7 +303,7 @@ class Daq:
 
     @property
     def _begin_timeout(self):
-        return BEGIN_TIMEOUT + self.config['stop_sleep']
+        return BEGIN_TIMEOUT + BEGIN_THROTTLE
 
     def begin_infinite(self, record=None, use_l3t=None, controls=None):
         """
@@ -437,7 +438,7 @@ class Daq:
                                      exc_info=True)
                 logger.debug('daq.control.begin(%s)', begin_args)
                 dt = time.time() - self._last_stop
-                tmo = self.config['stop_sleep'] - dt
+                tmo = BEGIN_THROTTLE - dt
                 if tmo > 0:
                     time.sleep(tmo)
                 control.begin(**begin_args)
@@ -532,8 +533,7 @@ class Daq:
         return {}
 
     def preconfig(self, events=None, duration=None, record=None, use_l3t=None,
-                  controls=None, begin_sleep=None, stop_sleep=None,
-                  show_queued_cfg=True):
+                  controls=None, begin_sleep=None, show_queued_cfg=True):
         """
         Queue configuration parameters for next call to `configure`.
 
@@ -553,10 +553,8 @@ class Daq:
             self._desired_config['events'] = None
             self._desired_config['duration'] = duration
 
-        for arg, name in zip((record, use_l3t, controls, begin_sleep,
-                              stop_sleep),
-                             ('record', 'use_l3t', 'controls', 'begin_sleep',
-                              'stop_sleep')):
+        for arg, name in zip((record, use_l3t, controls, begin_sleep),
+                             ('record', 'use_l3t', 'controls', 'begin_sleep')):
             if arg is not None:
                 self._desired_config[name] = arg
 
@@ -565,8 +563,7 @@ class Daq:
 
     @check_connect
     def configure(self, events=None, duration=None, record=None,
-                  use_l3t=None, controls=None, begin_sleep=None,
-                  stop_sleep=None):
+                  use_l3t=None, controls=None, begin_sleep=None):
         """
         Changes the daq's configuration for the next run.
 
@@ -608,11 +605,6 @@ class Daq:
             This is a hack because the DAQ often says that a begin transition
             is done without actually being done, so it needs a short delay.
 
-        stop_sleep: ``int``, optional
-            The amount of time to wait after the DAQ returns stop is done.
-            This is a hack because the DAQ often says that a stop transition
-            is done without actually being done, so it needs a short delay.
-
         Returns
         -------
         old, new: ``tuple`` of ``dict``
@@ -621,10 +613,8 @@ class Daq:
             at which they were configured, as specified by ``bluesky``.
         """
         logger.debug('Daq.configure(events=%s, duration=%s, record=%s, '
-                     'use_l3t=%s, controls=%s, begin_sleep=%s, '
-                     'stop_sleep=%s)',
-                     events, duration, record, use_l3t, controls, begin_sleep,
-                     stop_sleep)
+                     'use_l3t=%s, controls=%s, begin_sleep=%s)',
+                     events, duration, record, use_l3t, controls, begin_sleep)
         state = self.state
         if state not in ('Connected', 'Configured'):
             err = 'Cannot configure from state {}!'.format(state)
@@ -635,8 +625,7 @@ class Daq:
 
         self.preconfig(events=events, duration=duration, record=record,
                        use_l3t=use_l3t, controls=controls,
-                       begin_sleep=begin_sleep, stop_sleep=stop_sleep,
-                       show_queued_cfg=False)
+                       begin_sleep=begin_sleep, show_queued_cfg=False)
         config = self.next_config
 
         events = config['events']
@@ -645,14 +634,11 @@ class Daq:
         use_l3t = config['use_l3t']
         controls = config['controls']
         begin_sleep = config['begin_sleep']
-        stop_sleep = config['stop_sleep']
 
         logger.debug('Updated with queued config, now we have: '
                      'events=%s, duration=%s, record=%s, '
-                     'use_l3t=%s, controls=%s, begin_sleep=%s, '
-                     'stop_sleep=%s',
-                     events, duration, record, use_l3t, controls, begin_sleep,
-                     stop_sleep)
+                     'use_l3t=%s, controls=%s, begin_sleep=%s',
+                     events, duration, record, use_l3t, controls, begin_sleep)
 
         config_args = self._config_args(record, use_l3t, controls)
         try:
@@ -663,8 +649,7 @@ class Daq:
             # this is different than the arguments that pydaq.Control expects
             self._config = dict(events=events, duration=duration,
                                 record=record, use_l3t=use_l3t,
-                                controls=controls, begin_sleep=begin_sleep,
-                                stop_sleep=stop_sleep)
+                                controls=controls, begin_sleep=begin_sleep)
             self._update_config_ts()
             self.config_info(header='Daq configured:')
         except Exception as exc:
@@ -860,9 +845,6 @@ class Daq:
                                   dtype='array',
                                   shape=controls_shape),
                     begin_sleep=dict(source='daq_begin_sleep',
-                                     dtype='number',
-                                     shape=None),
-                    stop_sleep=dict(source='daq_stop_sleep',
                                      dtype='number',
                                      shape=None),
                     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from bluesky import RunEngine
 from ophyd.sim import SynSignal, motor1
 
+import pcdsdaq.daq as daq_module
 import pcdsdaq.sim.pyami as sim_pyami
 import pcdsdaq.sim.pydaq as sim_pydaq
 from pcdsdaq.ami import (AmiDet, _reset_globals as ami_reset_globals)
@@ -29,6 +30,7 @@ def nosim(reset):
 @pytest.fixture(scope='function')
 def daq(RE, sim):
     sim_pydaq.conn_err = None
+    daq_module.BEGIN_THROTTLE = 0
     daq = Daq(RE=RE)
     yield daq
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def nosim(reset):
 @pytest.fixture(scope='function')
 def daq(RE, sim):
     sim_pydaq.conn_err = None
-    daq = Daq(RE=RE, platform=0)
+    daq = Daq(RE=RE)
     yield daq
     try:
         # Sim daq can freeze pytest's exit if we don't end the run

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -88,14 +88,6 @@ def test_ami_errors(ami_det):
     logger.debug('test_ami_errors')
     with pytest.raises(Exception):
         ami_det.put(4)
-    set_pyami_proxy(None)
-    pcdsdaq.ami.pyami_connected = False
-    with pytest.raises(Exception):
-        AmiDet('NOPROXY', name='noproxy')
-    set_pyami_proxy('tst')
-    sim_pyami.connect_success = False
-    with pytest.raises(Exception):
-        AmiDet('NOCONN', name='noconn')
 
 
 def test_no_pyami():
@@ -153,13 +145,6 @@ def test_set_pyami_filter_all(ami_det):
     logger.debug('test_set_pyami_filter_all')
     set_pyami_filter(ami_det, 0, 1, ami_det, 2, 3, event_codes=[162, 163])
     assert sim_pyami.set_l3t_count == 1
-
-
-def test_set_pyami_filter_error(ami_det):
-    logger.debug('test_set_pyami_filter_error')
-    set_l3t_file(None)
-    with pytest.raises(Exception):
-        set_pyami_filter(event_codes=[21])
 
 
 def test_set_pyami_filter_daq(daq, ami_det):

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -8,8 +8,8 @@ from bluesky.plans import count
 
 import pcdsdaq.ami
 import pcdsdaq.sim.pyami as sim_pyami
-from pcdsdaq.ami import (AmiDet, auto_setup_pyami, set_pyami_proxy,
-                         set_l3t_file, set_monitor_det, set_pyami_filter,
+from pcdsdaq.ami import (AmiDet, auto_setup_pyami,
+                         set_monitor_det, set_pyami_filter,
                          dets_filter, concat_filter_strings)
 
 logger = logging.getLogger(__name__)
@@ -207,3 +207,10 @@ def test_auto_setup_pyami(sim, monkeypatch):
     monkeypatch.setattr(pcdsdaq.ami, 'import_module', fake_import)
 
     auto_setup_pyami()
+
+    # Now make sure we error if things are bad
+    pcdsdaq.ami._reset_globals()
+    sim_pyami.connect_success = False
+
+    with pytest.raises(RuntimeError):
+        auto_setup_pyami()

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -513,3 +513,12 @@ def test_complete_no_error(daq):
     # complete shouldn't error if we call it when the daq isn't running
     daq.configure(events=120)
     daq.complete()
+
+
+def test_begin_throttle(daq):
+    logger.debug('test_begin_throttle')
+    daq_module.BEGIN_THROTTLE = 1
+    start = time.time()
+    daq.stop()
+    daq.begin(duration=1)
+    assert 1 < time.time() - start < 3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Force the `Daq` class to wait at least `1s` between `stop` and `begin`. The timer starts on `stop`, and the sleep is skipped if enough other things have happened.

closes #40 

Also fix an unrelated bug where the `Daq` class wasn't correctly reset after a `disconnect`, and finally kill the deprecated argument.

I also redid some of the `ami` tests because they stopped working and the old tests didn't make sense to me any more.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Doing scans where there is very little going on between steps (e.g. no moves or really fast moves) AND there is enough during the step (`>0.05s` of action) results in `pydaq.Control.stop` routines that exit quickly but don't actually stop the daq in that time. Calling `pydaq.Control.begin` in this approx `0.45s` window when the `DAQ` claims to be ready to run causes the command to hang forever.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test added
