### PR TITLE
BUG: Begin timeout

### DIFF
--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -406,16 +406,16 @@ class Daq:
                 logger.debug(err, exc_info=True)
                 raise StateTransitionError(err)
 
-        if self.config['record']:
+        if self.state == 'Configured' and self.config['record']:
             try:
                 prev_run = self.run_number()
                 next_run = prev_run + 1
             except (RuntimeError, ValueError):
                 logger.debug('Error getting run number in kickoff',
                              exc_info=True)
+                next_run = None
         else:
             next_run = None
-
 
         def start_thread(control, status, events, duration, use_l3t, controls,
                          run_number):
@@ -451,7 +451,6 @@ class Daq:
             else:
                 logger.debug('Marking kickoff as failed')
                 status._finished(success=False)
-
 
         begin_status = Status(obj=self)
         watcher = threading.Thread(target=start_thread,

--- a/pcdsdaq/ext_scripts.py
+++ b/pcdsdaq/ext_scripts.py
@@ -27,17 +27,13 @@ def call_script(args, timeout=None, ignore_return_code=False):
         raise
 
 
-def hutch_name(timeout=None):
-    if timeout is None:
-        timeout = 5
+def hutch_name(timeout=5):
     script = SCRIPTS.format('latest', 'get_hutch_name')
     name = call_script(script, timeout=timeout)
     return name.lower().strip(' \n')
 
 
-def get_run_number(hutch=None, live=False, timeout=None):
-    if timeout is None:
-        timeout = 5
+def get_run_number(hutch=None, live=False, timeout=5):
     latest = hutch or 'latest'
     script = SCRIPTS.format(latest, 'get_lastRun')
     args = [script]
@@ -49,12 +45,10 @@ def get_run_number(hutch=None, live=False, timeout=None):
     return int(run_number)
 
 
-def get_ami_proxy(hutch, timeout=None):
+def get_ami_proxy(hutch, timeout=2):
     # This is mostly copied from old hutch python verbatim
     # I don't have useful explanations for what these regular expressions
     # are used for
-    if timeout is None:
-        timeout = 2
     domain_re = re.compile('.pcdsn$')
     ip_re = re.compile(r'^(?:[\d\.]{7,15}|[\w-]+)\s+ami_proxy'
                        r'\s+.*?\s+-I\s+(?P<ip>\d+\.\d+\.\d+\.\d+)\s+')

--- a/pcdsdaq/ext_scripts.py
+++ b/pcdsdaq/ext_scripts.py
@@ -27,13 +27,17 @@ def call_script(args, timeout=None, ignore_return_code=False):
         raise
 
 
-def hutch_name():
+def hutch_name(timeout=None):
+    if timeout is None:
+        timeout = 5
     script = SCRIPTS.format('latest', 'get_hutch_name')
-    name = call_script(script)
+    name = call_script(script, timeout=timeout)
     return name.lower().strip(' \n')
 
 
-def get_run_number(hutch=None, live=False):
+def get_run_number(hutch=None, live=False, timeout=None):
+    if timeout is None:
+        timeout = 5
     latest = hutch or 'latest'
     script = SCRIPTS.format(latest, 'get_lastRun')
     args = [script]
@@ -41,14 +45,16 @@ def get_run_number(hutch=None, live=False):
         args += ['-i', hutch]
     if live:
         args += ['-l']
-    run_number = call_script(args)
+    run_number = call_script(args, timeout=timeout)
     return int(run_number)
 
 
-def get_ami_proxy(hutch):
+def get_ami_proxy(hutch, timeout=None):
     # This is mostly copied from old hutch python verbatim
     # I don't have useful explanations for what these regular expressions
     # are used for
+    if timeout is None:
+        timeout = 2
     domain_re = re.compile('.pcdsn$')
     ip_re = re.compile(r'^(?:[\d\.]{7,15}|[\w-]+)\s+ami_proxy'
                        r'\s+.*?\s+-I\s+(?P<ip>\d+\.\d+\.\d+\.\d+)\s+')
@@ -56,7 +62,7 @@ def get_ami_proxy(hutch):
     cnf = CNF.format(hutch)
     procmgr = TOOLS.format('procmgr', 'procmgr')
     output = call_script([procmgr, 'status', cnf, 'ami_proxy'],
-                         timeout=2,
+                         timeout=timeout,
                          ignore_return_code=True)
     for line in output.split('\n'):
         ip_match = ip_re.match(line)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This PR fixes a race condition in `Daq.begin` that would cause failed starts when the external scripts we call get slow. There was an assumption that the timeout for `begin` would only account for `pydaq` time, but this is not the case.

Now we have separate timeouts for `begin` and for the external scripts.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#65 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with the real DAQ, hopefully the tests still pass

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This will be in the notes for the next release.

<!--
## Screenshots (if appropriate):
-->
