### PR TITLE
ENH: Various updates for Better Ops

### DIFF
--- a/pcdsdaq/ami.py
+++ b/pcdsdaq/ami.py
@@ -121,7 +121,7 @@ def set_monitor_det(det):
         globals()['monitor_det'] = None
 
 
-def set_pyami_filter(*args, event_codes=None, operator='&', or_bykik=True):
+def set_pyami_filter(*args, event_codes=None, operator='&', or_bykik=False):
     """
     Set up the l3t filters.
 
@@ -159,7 +159,7 @@ def set_pyami_filter(*args, event_codes=None, operator='&', or_bykik=True):
         filters pass.
 
     or_bykik: ``bool``, optional
-        True by default, appends an ``or`` condition that marks l3t pass when
+        False by default, appends an ``or`` condition that marks l3t pass when
         we see the bykik event code. This makes sure the off shots make it into
         the data if we're in l3t veto mode.
     """

--- a/pcdsdaq/ami.py
+++ b/pcdsdaq/ami.py
@@ -126,43 +126,42 @@ def set_pyami_filter(*args, event_codes=None, operator='&', or_bykik=False):
     Set up the l3t filters.
 
     These connect through pyami to call set_l3t or clear_l3t. The function
-    takes in arbitrary dets whose prefixes are the ami names, along with low
-    and highs.
+    takes in arbitrary dets whose prefixes are the ami names, along with
+    low and highs.
 
-    Event codes are handled as a special case, since you always want high vs
-    low.
+    Event codes are handled as a special case, since you always want high
+    vs low.
 
     .. note::
-        By default this will treat bykik at an l3t pass! This is so you don't
-        lose your off shots when the l3t trigger is in veto mode. You can
-        disable this with ``or_bykik=False``, but this will remain the default
-        behavior for backwards compatibility and to prevent someone from losing
-        shots that they wanted in the data.
+        If or_bykik is True, this will treat bykik at an l3t pass! This is
+        so you don't lose your off shots when the l3t trigger is in veto
+        mode.
 
     Parameters
     ----------
     *args: (`AmiDet`, ``float``, ``float``) n times
         A sequence of (detector, low, high), which create filters that make
         sure the detector is between low and high. You can omit the first
-        `AmiDet` as a shorthand for the current monitor, assuming a monitor has
-        been set with `Daq.set_monitor` or `set_monitor_det`.
+        `AmiDet` as a shorthand for the current monitor, assuming a monitor
+        has been set with `Daq.set_monitor` or `set_monitor_det`.
 
     event_codes: ``list``, optional
-        A list of event codes to include in the filter. l3pass will be when the
-        event code is present.
+        A list of event codes to include in the filter. l3pass will be when
+        the event code is present.
 
     operator: ``str``, optional
-        The operator for combining the detector ranges and event codes. This
-        can either be ``|`` to ``or`` the conditions together, so l3pass will
-        happen if any filter passes, or it can be left at the default ``&`` to
-        ``and`` the conditions together, so l3pass will only happen if all
-        filters pass.
+        The operator for combining the detector ranges and event codes.
+        This can either be ``|`` to ``or`` the conditions together, so
+        l3pass will happen if any filter passes, or it can be left at
+        the default ``&`` to ``and`` the conditions together, so l3pass
+        will only happen if all filters pass.
 
     or_bykik: ``bool``, optional
-        False by default, appends an ``or`` condition that marks l3t pass when
-        we see the bykik event code. This makes sure the off shots make it into
-        the data if we're in l3t veto mode.
+        False by default, appends an ``or`` condition that marks l3t pass
+        when we see the bykik event code. This makes sure the off shots
+        make it into the data if we're in l3t veto mode.
     """
+
     auto_setup_pyami()
     filter_string = dets_filter(*args, event_codes=event_codes,
                                 operator=operator, or_bykik=or_bykik)

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -1006,7 +1006,48 @@ class Daq:
         except Exception:
             pass
 
-    def set_filter(self, *args, event_codes=None, operator='&', or_bykik=True):
+    def set_filter(self, *args, event_codes=None, operator='&', or_bykik=False):
+        """
+        Set up the l3t filters.
+
+        These connect through pyami to call set_l3t or clear_l3t. The function
+        takes in arbitrary dets whose prefixes are the ami names, along with low
+        and highs.
+
+        Event codes are handled as a special case, since you always want high vs
+        low.
+
+        .. note::
+            By default this will treat bykik at an l3t pass! This is so you don't
+            lose your off shots when the l3t trigger is in veto mode. You can
+            disable this with ``or_bykik=False``, but this will remain the default
+            behavior for backwards compatibility and to prevent someone from losing
+            shots that they wanted in the data.
+
+        Parameters
+        ----------
+        *args: (`AmiDet`, ``float``, ``float``) n times
+            A sequence of (detector, low, high), which create filters that make
+            sure the detector is between low and high. You can omit the first
+            `AmiDet` as a shorthand for the current monitor, assuming a monitor has
+            been set with `Daq.set_monitor` or `set_monitor_det`.
+
+        event_codes: ``list``, optional
+            A list of event codes to include in the filter. l3pass will be when the
+            event code is present.
+
+        operator: ``str``, optional
+            The operator for combining the detector ranges and event codes. This
+            can either be ``|`` to ``or`` the conditions together, so l3pass will
+            happen if any filter passes, or it can be left at the default ``&`` to
+            ``and`` the conditions together, so l3pass will only happen if all
+            filters pass.
+
+        or_bykik: ``bool``, optional
+            False by default, appends an ``or`` condition that marks l3t pass when
+            we see the bykik event code. This makes sure the off shots make it into
+            the data if we're in l3t veto mode.
+        """
         return set_pyami_filter(*args, event_codes=event_codes,
                                 operator=operator, or_bykik=or_bykik)
     set_filter.__doc__ = set_pyami_filter.__doc__

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -1006,51 +1006,50 @@ class Daq:
         except Exception:
             pass
 
-    def set_filter(self, *args, event_codes=None, operator='&', or_bykik=False):
+    def set_filter(self, *args, event_codes=None, operator='&',
+                   or_bykik=False):
         """
         Set up the l3t filters.
 
         These connect through pyami to call set_l3t or clear_l3t. The function
-        takes in arbitrary dets whose prefixes are the ami names, along with low
-        and highs.
+        takes in arbitrary dets whose prefixes are the ami names, along with
+        low and highs.
 
-        Event codes are handled as a special case, since you always want high vs
-        low.
+        Event codes are handled as a special case, since you always want high
+        vs low.
 
         .. note::
-            By default this will treat bykik at an l3t pass! This is so you don't
-            lose your off shots when the l3t trigger is in veto mode. You can
-            disable this with ``or_bykik=False``, but this will remain the default
-            behavior for backwards compatibility and to prevent someone from losing
-            shots that they wanted in the data.
+            If or_bykik is True, this will treat bykik at an l3t pass! This is
+            so you don't lose your off shots when the l3t trigger is in veto
+            mode.
 
         Parameters
         ----------
         *args: (`AmiDet`, ``float``, ``float``) n times
             A sequence of (detector, low, high), which create filters that make
             sure the detector is between low and high. You can omit the first
-            `AmiDet` as a shorthand for the current monitor, assuming a monitor has
-            been set with `Daq.set_monitor` or `set_monitor_det`.
+            `AmiDet` as a shorthand for the current monitor, assuming a monitor
+            has been set with `Daq.set_monitor` or `set_monitor_det`.
 
         event_codes: ``list``, optional
-            A list of event codes to include in the filter. l3pass will be when the
-            event code is present.
+            A list of event codes to include in the filter. l3pass will be when
+            the event code is present.
 
         operator: ``str``, optional
-            The operator for combining the detector ranges and event codes. This
-            can either be ``|`` to ``or`` the conditions together, so l3pass will
-            happen if any filter passes, or it can be left at the default ``&`` to
-            ``and`` the conditions together, so l3pass will only happen if all
-            filters pass.
+            The operator for combining the detector ranges and event codes.
+            This can either be ``|`` to ``or`` the conditions together, so
+            l3pass will happen if any filter passes, or it can be left at
+            the default ``&`` to ``and`` the conditions together, so l3pass
+            will only happen if all filters pass.
 
         or_bykik: ``bool``, optional
-            False by default, appends an ``or`` condition that marks l3t pass when
-            we see the bykik event code. This makes sure the off shots make it into
-            the data if we're in l3t veto mode.
+            False by default, appends an ``or`` condition that marks l3t pass
+            when we see the bykik event code. This makes sure the off shots
+            make it into the data if we're in l3t veto mode.
         """
+
         return set_pyami_filter(*args, event_codes=event_codes,
                                 operator=operator, or_bykik=or_bykik)
-    set_filter.__doc__ = set_pyami_filter.__doc__
 
     def set_monitor(self, det):
         return set_monitor_det(det)

--- a/pcdsdaq/ext_scripts.py
+++ b/pcdsdaq/ext_scripts.py
@@ -30,12 +30,13 @@ def call_script(args, timeout=None, ignore_return_code=False):
 cache = {}
 
 
-def cache_script(args, timeout=None):
+def cache_script(args, timeout=None, ignore_return_code=False):
     key = ' '.join(args)
     try:
         return cache[key]
     except KeyError:
-        output = call_script(args, timeout=timeout)
+        output = call_script(args, timeout=timeout,
+                             ignore_return_code=ignore_return_code)
         cache[key] = output
         return output
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Change bykik code to `False` by default in `set_filter` as per Silke's instructions
- Give up on the run_number getter on the first failure per session, it is merely cosmetic and should not slow down the scan.
- Decrease the get run number timeout to 1s.
- Copy the good docstring for `set_filter` over to the daq method
- Increase timeouts for get_hutch and get_ami_proxy, then cache the result. The result does not change.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Various changes requested between shifts
- closes #72 
