### PR TITLE
MNT: Allow Controls Arg to Accept PseudoPositioners

### DIFF
--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -767,7 +767,7 @@ class Daq:
                 val = device.get()
             try:
                 val = val[0]
-            except IndexError:
+            except Exception:
                 pass
             ctrl_arg.append((name, val))
         return ctrl_arg

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -765,6 +765,10 @@ class Daq:
                 val = device.position
             except AttributeError:
                 val = device.get()
+            try:
+                val = val[0]
+            except IndexError:
+                pass
             ctrl_arg.append((name, val))
         return ctrl_arg
 

--- a/pcdsdaq/sim/pydaq.py
+++ b/pcdsdaq/sim/pydaq.py
@@ -1,3 +1,4 @@
+import numbers
 import time
 import threading
 import logging
@@ -92,6 +93,14 @@ class Control:
                 raise RuntimeError('configure requires events or duration')
             else:
                 self._duration = dur
+            if controls is not None:
+                for name, value in controls:
+                    if not isinstance(name, str):
+                        raise RuntimeError('Expected a string name, got '
+                                           f'{name}')
+                    if not isinstance(value, numbers.Number):
+                        raise RuntimeError('Expected a numeric position, got '
+                                           f'{value}')
 
     def begin(self, *, events=None, l1t_events=None, l3t_events=None,
               duration=None, controls=None, monitors=None):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- When doing our value stuffing of the controls arg to pass to pydaq, add a step where we get the first element of the motor position if it was a tuple, list or similar.
- Add a failure state to the sim pydaq based on #77 for testing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #77 
PseudoPositioners have position attributes that are named tuples. The first element in the tuple is the most important, and therefore the one most likely to be sought after if the user passes in the entire pseudopositioner. Therefore, taking the first element to report to the DAQ will be sufficient for this use case.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with the sim pydaq

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Not yet
<!--
## Screenshots (if appropriate):
-->
