### PR TITLE
ENH: Allow hutch to be passed into DAQ instead of using scripts

### DIFF
--- a/pcdsdaq/ami.py
+++ b/pcdsdaq/ami.py
@@ -55,6 +55,9 @@ def auto_setup_pyami():
     top of this file because we need to be able to import this file even if
     pyami isn't in the environment, which is semi-frequent.
     """
+    global pyami
+    global pyami_connected
+
     if None in (ami_proxy, l3t_file):
         # get_hutch_name fails if not on nfs
         # or on a bad nfs day, so only do if 100% needed
@@ -69,28 +72,29 @@ def auto_setup_pyami():
 
     if pyami is None:
         logger.debug('importing pyami')
-        globals()['pyami'] = import_module('pyami')
+        pyami = import_module('pyami')
 
     if not pyami_connected:
         logger.debug('initializing pyami')
         try:
             pyami.connect(ami_proxy)
-            globals()['pyami_connected'] = True
+            pyami_connected = True
         except Exception:
-            globals()['pyami_connected'] = False
+            pyami_connected = False
             raise
 
 
-def set_ami_hutch(hutch_name):
+def set_ami_hutch(name):
     """
     Pick the hutch name to skip a shell out to get_hutch_name.
 
     Parameters
     ----------
-    hutch_name: ``str``
+    name: ``str``
         Name of the hutch
     """
-    globals()['hutch_name'] = hutch_name.lower()
+    global hutch_name
+    hutch_name = name.lower()
 
 
 def set_pyami_proxy(proxy):
@@ -102,19 +106,21 @@ def set_pyami_proxy(proxy):
     proxy: ``str`` or ``int``
         Either the server name or group number
     """
-    globals()['ami_proxy'] = proxy
+    global ami_proxy
+    ami_proxy = proxy
 
 
-def set_l3t_file(l3t_file):
+def set_l3t_file(filename):
     """
     Pick the file to write out for the l3t trigger
 
     Parameters
     ----------
-    l3t_file: ``str``
+    filename: ``str``
         Full file path
     """
-    globals()['l3t_file'] = l3t_file
+    global l3t_file
+    l3t_file = filename
 
 
 def set_monitor_det(det):
@@ -130,10 +136,11 @@ def set_monitor_det(det):
         The detector to set as the monitor. Alternatively, pass in ``False`` to
         disable the monitor det.
     """
+    global monitor_det
     if det:
-        globals()['monitor_det'] = det
+        monitor_det = det
     else:
-        globals()['monitor_det'] = None
+        monitor_det = None
 
 
 def set_pyami_filter(*args, event_codes=None, operator='&', or_bykik=False):
@@ -176,6 +183,7 @@ def set_pyami_filter(*args, event_codes=None, operator='&', or_bykik=False):
         when we see the bykik event code. This makes sure the off shots
         make it into the data if we're in l3t veto mode.
     """
+    global last_filter_string
 
     auto_setup_pyami()
     filter_string = dets_filter(*args, event_codes=event_codes,
@@ -184,7 +192,7 @@ def set_pyami_filter(*args, event_codes=None, operator='&', or_bykik=False):
         pyami.clear_l3t()
     else:
         pyami.set_l3t(filter_string, l3t_file)
-        globals()['last_filter_string'] = filter_string
+        last_filter_string = filter_string
 
 
 def dets_filter(*args, event_codes=None, operator='&', or_bykik=True):

--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -74,6 +74,9 @@ class Daq:
     ----------
     RE: ``RunEngine``, optional
         Set ``RE`` to the session's main ``RunEngine``
+
+    hutch_name: str, optional
+        Definte a hutch name to use instead of shelling out to get_hutch_name.
     """
     _state_enum = enum.Enum('PydaqState',
                             'Disconnected Connected Configured Open Running',

--- a/pcdsdaq/ext_scripts.py
+++ b/pcdsdaq/ext_scripts.py
@@ -46,10 +46,14 @@ def clear_script_cache():
     cache = {}
 
 
-def hutch_name(timeout=10):
+def get_hutch_name(timeout=10):
     script = SCRIPTS.format('latest', 'get_hutch_name')
     name = cache_script(script, timeout=timeout)
     return name.lower().strip(' \n')
+
+
+# API Backwards compatibility
+hutch_name = get_hutch_name
 
 
 def get_run_number(hutch=None, live=False, timeout=1):

--- a/pcdsdaq/sim/__init__.py
+++ b/pcdsdaq/sim/__init__.py
@@ -44,5 +44,4 @@ def set_sim_mode(sim_mode):
         except ImportError:
             logger.error('pydaq not available in this session')
         ext.get_hutch_name = pydaq.get_hutch_name
-        ext.get_hutch_name = pydaq.get_hutch_name
         ext.get_run_number = pydaq.get_run_number

--- a/pcdsdaq/sim/__init__.py
+++ b/pcdsdaq/sim/__init__.py
@@ -28,7 +28,7 @@ def set_sim_mode(sim_mode):
             ami.set_pyami_proxy('tstproxy')
             ami.set_l3t_file('tstfile')
         daq.pydaq = pydaq
-        ext.hutch_name = pydaq.sim_hutch_name
+        ext.get_hutch_name = pydaq.sim_get_hutch_name
         ext.get_run_number = pydaq.sim_get_run_number
     else:
         if ami.ami_proxy == 'tstproxy':
@@ -43,6 +43,6 @@ def set_sim_mode(sim_mode):
             daq.pydaq = real_pydaq
         except ImportError:
             logger.error('pydaq not available in this session')
-        ext.hutch_name = pydaq.hutch_name
-        ext.hutch_name = pydaq.hutch_name
+        ext.get_hutch_name = pydaq.get_hutch_name
+        ext.get_hutch_name = pydaq.get_hutch_name
         ext.get_run_number = pydaq.get_run_number

--- a/pcdsdaq/sim/pydaq.py
+++ b/pcdsdaq/sim/pydaq.py
@@ -4,7 +4,7 @@ import threading
 import logging
 
 from pcdsdaq.daq import Daq
-from pcdsdaq.ext_scripts import hutch_name, get_run_number  # NOQA
+from pcdsdaq.ext_scripts import get_hutch_name, get_run_number  # NOQA
 
 logger = logging.getLogger(__name__)
 
@@ -195,7 +195,7 @@ class Control:
         self._done_flag.wait()
 
 
-def sim_hutch_name():
+def sim_get_hutch_name():
     return 'tst'
 
 

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -203,7 +203,7 @@ def test_auto_setup_pyami(sim, monkeypatch):
         else:
             return importlib.import_module(module)
 
-    monkeypatch.setattr(pcdsdaq.ami, 'hutch_name', fake_hutch_name)
+    monkeypatch.setattr(pcdsdaq.ami, 'get_hutch_name', fake_hutch_name)
     monkeypatch.setattr(pcdsdaq.ami, 'get_ami_proxy', fake_get_proxy)
     monkeypatch.setattr(pcdsdaq.ami, 'import_module', fake_import)
 

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -536,4 +536,3 @@ def test_timeouts(daq, monkeypatch):
         daq._control._begin_delay = 3
         daq.begin(duration=1)
     daq.stop()
-

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -536,3 +536,10 @@ def test_timeouts(daq, monkeypatch):
         daq._control._begin_delay = 3
         daq.begin(duration=1)
     daq.stop()
+
+
+def test_pass_hutch(sim):
+    logger.debug('test_pass_hutch')
+    # Mainly for coverage, make sure no typos in the chain here
+    daq = daq_module.Daq(hutch_name='tst')
+    assert daq.hutch_name == 'tst'

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -475,7 +475,7 @@ def test_run_number(daq, monkeypatch):
     def no_file(*args, **kwargs):
         raise FileNotFoundError('test')
 
-    monkeypatch.setattr(ext, 'hutch_name', no_file)
+    monkeypatch.setattr(ext, 'get_hutch_name', no_file)
 
     with pytest.raises(RuntimeError):
         daq.run_number()

--- a/tests/test_ext_scripts.py
+++ b/tests/test_ext_scripts.py
@@ -27,7 +27,7 @@ def test_hutch_name(nosim, monkeypatch):
         return 'tst\n'
 
     monkeypatch.setattr(ext, 'call_script', fake_hutch_name)
-    assert ext.hutch_name() == 'tst'
+    assert ext.get_hutch_name() == 'tst'
 
 
 def test_run_number(nosim, monkeypatch):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
- Add `hutch_name` as an argument to the `Daq` class to skip calling the `get_hutch_name` external script
- Rename `hutch_name()` to `get_hutch_name()` for clarity

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- `get_hutch_name()` can be slow and we know what hutch we're in before calling it
- closes #76 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Basic coverage test added

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
- Docstrings

<!--
## Screenshots (if appropriate):
-->
