### PR TITLE
MNT: do not disconnect the DAQ in unstage ever, as this is disruptive

### DIFF
--- a/pcdsdaq/daq.py
+++ b/pcdsdaq/daq.py
@@ -961,12 +961,11 @@ class Daq:
         # If we're still running, end now
         if self.state in ('Open', 'Running'):
             self.end_run()
-        # Return to the state we had at stage
-        if self._pre_run_state == 'Disconnected':
-            self.disconnect()
-        elif self._pre_run_state == 'Running':
+        # Return to running if we already were (to keep AMI running)
+        if self._pre_run_state == 'Running':
             self.begin_infinite()
         # For other states, end_run was sufficient.
+        # E.g. do not disconnect, or this would close the open plots!
         return [self]
 
     def pause(self):

--- a/tests/test_daq.py
+++ b/tests/test_daq.py
@@ -374,7 +374,7 @@ def test_restore_state(daq, RE):
     assert daq.state == 'Disconnected'
     daq.preconfig(events=1)
     RE(count([daq]))
-    assert daq.state == 'Disconnected'
+    assert daq.state == 'Configured'
 
     daq.begin_infinite()
     assert daq.state == 'Running'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Remove the "disconnect if we weren't connected" clause, this was taking the "return to previous state" mantra too far.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This closes the open DAQ/AMI plots, which the scientists would have liked to keep looking at after a run.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A, maybe this even breaks the test suite idk

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
N/A

<!--
## Screenshots (if appropriate):
-->
