### PR TITLE
ENH/FIX: fill in scan PVs properly from most normal scan types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ env:
     # CONDA_EXTRAS) but for pip
     - PIP_EXTRAS=""
 
-jobs:
-  allow_failures:
-    - name: "Python - PIP"
+#jobs:
+#  allow_failures:
+#    - name: "Python - PIP"
 
 import:
   # This import enables a set of standard python jobs including:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,11 @@ env:
     # CONDA_EXTRAS) but for pip
     - PIP_EXTRAS=""
 
-#jobs:
-#  allow_failures:
+jobs:
+  allow_failures:
+    - name: "Pre-commit Checks"
 #    - name: "Python - PIP"
+
 
 import:
   # This import enables a set of standard python jobs including:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   allow_failures:
-    - name: "Python 3.6 - PIP"
+    - name: "Python - PIP"
 
 import:
   # This import enables a set of standard python jobs including:

--- a/pcdsdaq/scan_vars.py
+++ b/pcdsdaq/scan_vars.py
@@ -161,8 +161,8 @@ class ScanVars(Device, CallbackBase):
         then a num later, such as the normal scan.
         """
         # check for start/stop points
-        motor_info = plan_pattern_args['args']
-        for index, (_, start, stop) in enumerate(partition(3, motor_info)):
+        per_motor = enumerate(partition(3, plan_pattern_args['args']))
+        for index, (_, start, stop) in per_motor:
             if index >= self.MAX_VARS:
                 break
             self.update_min_max(start, stop, index)
@@ -203,8 +203,7 @@ class ScanVars(Device, CallbackBase):
         scan with multiple motors, such as list_scan.
         """
         # check for start/stop points
-        args = plan_pattern_args['args']
-        for index, (_, points) in enumerate(args):
+        for index, (_, points) in enumerate(plan_pattern_args['args']):
             if index >= self.MAX_VARS:
                 break
             self.update_min_max(min(points), max(points), index)
@@ -225,9 +224,8 @@ class ScanVars(Device, CallbackBase):
         mesh scan, like list_grid_scan.
         """
         # check for start/stop points
-        args = plan_pattern_args['args']
         product_num = 1
-        for index, (_, points) in args:
+        for index, (_, points) in plan_pattern_args['args']:
             if index >= self.MAX_VARS:
                 break
             self.update_min_max(min(points), max(points), index)

--- a/pcdsdaq/scan_vars.py
+++ b/pcdsdaq/scan_vars.py
@@ -103,6 +103,7 @@ class ScanVars(Device, CallbackBase):
             # there are other patterns, but that's all we'll handle for now
             plan_pattern = doc.get('plan_pattern')
 
+            # in this block we find the min/max and number of points
             try:
                 plan_pattern_args = doc['plan_pattern_args']
             except KeyError:
@@ -118,11 +119,18 @@ class ScanVars(Device, CallbackBase):
                     elif plan_pattern == 'outer_list_product':
                         self.setup_outer_list_product(plan_pattern_args)
                     else:
+                        logger.error(
+                            'Encountered unknown plan type, '
+                            'did not set up min/max/num scan PVs.'
+                        )
                         logger.debug(
                             'No scan var setup for plan_pattern %s',
                             plan_pattern,
                         )
                 except Exception:
+                    logger.error(
+                        'Error setting up min/max/num scan PVs'
+                    )
                     logger.debug(
                         'Error setting up plan_pattern %s',
                         plan_pattern,

--- a/pcdsdaq/scan_vars.py
+++ b/pcdsdaq/scan_vars.py
@@ -147,6 +147,8 @@ class ScanVars(Device, CallbackBase):
         """
         Helper function for updating the min and max PVs for the scan table.
         """
+        if index >= self.MAX_VARS:
+            return
         sig_max = getattr(self, f'var{index}_max')
         sig_min = getattr(self, f'var{index}_min')
         sig_max.put(max(start, stop))

--- a/pcdsdaq/scan_vars.py
+++ b/pcdsdaq/scan_vars.py
@@ -96,6 +96,14 @@ class ScanVars(Device, CallbackBase):
             except KeyError:
                 logger.debug('Skip var names, no "motors" in start doc')
 
+            # check for a top level number of points, this is often present
+            try:
+                num_points = doc['num_points']
+            except KeyError:
+                pass
+            else:
+                self.n_steps.put(num_points)
+
             # check the plan pattern, determines how we read the args
             # inner_product is mot, start, stop, (repeat), num
             # outer_product is mot, start, stop, num, (repeat) + snakes

--- a/pcdsdaq/scan_vars.py
+++ b/pcdsdaq/scan_vars.py
@@ -216,7 +216,8 @@ class ScanVars(Device, CallbackBase):
         scan with multiple motors, such as list_scan.
         """
         # check for start/stop points
-        for index, (_, points) in enumerate(plan_pattern_args['args']):
+        per_motor = partition(2, plan_pattern_args['args'])
+        for index, (_, points) in enumerate(per_motor):
             if index >= self.MAX_VARS:
                 break
             self.update_min_max(min(points), max(points), index)
@@ -237,8 +238,9 @@ class ScanVars(Device, CallbackBase):
         mesh scan, like list_grid_scan.
         """
         # check for start/stop points
+        per_motor = partition(2, plan_pattern_args['args'])
         product_num = 1
-        for index, (_, points) in enumerate(plan_pattern_args['args']):
+        for index, (_, points) in enumerate(per_motor):
             if index >= self.MAX_VARS:
                 break
             self.update_min_max(min(points), max(points), index)

--- a/pcdsdaq/scan_vars.py
+++ b/pcdsdaq/scan_vars.py
@@ -122,7 +122,7 @@ class ScanVars(Device, CallbackBase):
                 logger.debug('No plan pattern, skip max/min/num from shape')
                 if not has_top_level_num:
                     logger.error(
-                        'Could not determine any max/min/num info for '
+                        'Scan PVs will be missing any max/min/num info for '
                         'this scan due to invalid or missing metadata.'
                     )
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import sys
+
 from bluesky import RunEngine
 from ophyd.sim import SynSignal, motor1
 
@@ -29,6 +31,8 @@ def nosim(reset):
 
 @pytest.fixture(scope='function')
 def daq(RE, sim):
+    if sys.platform == 'win32':
+        pytest.skip('Cannot make DAQ on windows')
     sim_pydaq.conn_err = None
     daq_module.BEGIN_THROTTLE = 0
     daq = Daq(RE=RE)

--- a/tests/test_scan_vars.py
+++ b/tests/test_scan_vars.py
@@ -126,6 +126,24 @@ def test_scan_vars_no_daq(RE):
             }
         ),
         (
+            grid_scan,
+            (
+                [],
+                motor1, 0, 11, 2,
+                motor2, 10, 12, 3, False,
+                motor3, 20, 23, 2, True,
+            ),
+            {
+                'var0_max': 11,
+                'var1_max': 12,
+                'var2_max': 23,
+                'var0_min': 0,
+                'var1_min': 10,
+                'var2_min': 20,
+                'n_steps': 12,
+            }
+        ),
+        (
             list_scan,
             ([], motor1, [0, 1], motor2, [10, 11], motor3, [20, 21]),
             {

--- a/tests/test_scan_vars.py
+++ b/tests/test_scan_vars.py
@@ -99,6 +99,7 @@ def test_scan_vars_no_daq(RE):
 @pytest.mark.parametrize(
     "plan,args,expected",
     [
+        (count, ([], 5), {'n_steps': 5}),
         (
             scan,
             ([], motor1, 0, 11, motor2, 10, 12, motor3, 20, 23, 5),

--- a/tests/test_scan_vars.py
+++ b/tests/test_scan_vars.py
@@ -1,7 +1,7 @@
 import logging
 
 from bluesky.callbacks.core import CallbackBase
-from bluesky.plans import count, scan
+from bluesky.plans import count, scan, grid_scan, list_scan, list_grid_scan
 from bluesky.plan_stubs import create, read, save
 from bluesky.preprocessors import run_wrapper, stage_wrapper
 from ophyd.signal import Signal
@@ -9,6 +9,8 @@ from ophyd.sim import motor, motor1, motor2, motor3, det1, det2
 
 import pcdsdaq.daq
 from pcdsdaq.scan_vars import ScanVars
+
+import pytest
 
 logger = logging.getLogger(__name__)
 
@@ -92,3 +94,81 @@ def test_scan_vars_no_daq(RE):
     pcdsdaq.daq._daq_instance = None
     scan_vars = ScanVars('TST', name='tst', RE=RE)
     scan_vars.start({})
+
+
+@pytest.mark.parametrize(
+    "plan,args,expected",
+    [
+        (
+            scan,
+            ([], motor1, 0, 11, motor2, 10, 12, motor3, 20, 23, 100),
+            {
+                'var0_max': 11,
+                'var1_max': 12,
+                'var2_max': 23,
+                'var0_min': 0,
+                'var1_min': 10,
+                'var2_min': 20,
+                'n_steps': 100,
+            }
+        ),
+        (
+            grid_scan,
+            ([], motor1, 0, 11, 10, motor2, 10, 12, 10, motor3, 20, 23, 10),
+            {
+                'var0_max': 11,
+                'var1_max': 12,
+                'var2_max': 23,
+                'var0_min': 0,
+                'var1_min': 10,
+                'var2_min': 20,
+                'n_steps': 1000,
+            }
+        ),
+        (
+            list_scan,
+            ([], motor1, [0, 1], motor2, [10, 11], motor3, [20, 21]),
+            {
+                'var0_max': 1,
+                'var1_max': 11,
+                'var2_max': 21,
+                'var0_min': 0,
+                'var1_min': 10,
+                'var2_min': 20,
+                'n_steps': 2,
+            }
+        ),
+        (
+            list_grid_scan,
+            ([], motor1, [0, 1], motor2, [10, 11], motor3, [20, 21]),
+            {
+                'var0_max': 1,
+                'var1_max': 11,
+                'var2_max': 21,
+                'var0_min': 0,
+                'var1_min': 10,
+                'var2_min': 20,
+                'n_steps': 8,
+            }
+        ),
+    ]
+)
+def test_scan_vars_with_plans(RE, plan, args, expected):
+    """
+    Can we get basic scan information correctly with different scan types?
+    """
+    logger.debug('test_scan_vars_with_plans')
+
+    scan_vars = ScanVars('TST', name='tst', RE=RE)
+    scan_vars.enable()
+
+    initial_values = {}
+
+    def cache_initial_values(name, _):
+        if name == 'descriptor':
+            for key in expected:
+                initial_values[key] = getattr(scan_vars, key).get()
+
+    RE.subscribe(cache_initial_values)
+    RE(plan(*args))
+    assert initial_values == expected

--- a/tests/test_scan_vars.py
+++ b/tests/test_scan_vars.py
@@ -101,7 +101,7 @@ def test_scan_vars_no_daq(RE):
     [
         (
             scan,
-            ([], motor1, 0, 11, motor2, 10, 12, motor3, 20, 23, 100),
+            ([], motor1, 0, 11, motor2, 10, 12, motor3, 20, 23, 5),
             {
                 'var0_max': 11,
                 'var1_max': 12,
@@ -109,12 +109,12 @@ def test_scan_vars_no_daq(RE):
                 'var0_min': 0,
                 'var1_min': 10,
                 'var2_min': 20,
-                'n_steps': 100,
+                'n_steps': 5,
             }
         ),
         (
             grid_scan,
-            ([], motor1, 0, 11, 10, motor2, 10, 12, 10, motor3, 20, 23, 10),
+            ([], motor1, 0, 11, 2, motor2, 10, 12, 3, motor3, 20, 23, 2),
             {
                 'var0_max': 11,
                 'var1_max': 12,
@@ -122,7 +122,7 @@ def test_scan_vars_no_daq(RE):
                 'var0_min': 0,
                 'var1_min': 10,
                 'var2_min': 20,
-                'n_steps': 1000,
+                'n_steps': 12,
             }
         ),
         (
@@ -140,15 +140,15 @@ def test_scan_vars_no_daq(RE):
         ),
         (
             list_grid_scan,
-            ([], motor1, [0, 1], motor2, [10, 11], motor3, [20, 21]),
+            ([], motor1, [0, 1], motor2, [10, 11, 12], motor3, [20, 21]),
             {
                 'var0_max': 1,
-                'var1_max': 11,
+                'var1_max': 12,
                 'var2_max': 21,
                 'var0_min': 0,
                 'var1_min': 10,
                 'var2_min': 20,
-                'n_steps': 8,
+                'n_steps': 12,
             }
         ),
     ]
@@ -165,7 +165,7 @@ def test_scan_vars_with_plans(RE, plan, args, expected):
     initial_values = {}
 
     def cache_initial_values(name, _):
-        if name == 'descriptor':
+        if name == 'event' and not initial_values:
             for key in expected:
                 initial_values[key] = getattr(scan_vars, key).get()
 

--- a/tests/test_scan_vars.py
+++ b/tests/test_scan_vars.py
@@ -99,7 +99,7 @@ def test_scan_vars_no_daq(RE):
 @pytest.mark.parametrize(
     "plan,args,expected",
     [
-        (count, ([], 5), {'n_steps': 5}),
+        (count, ([det1], 5), {'n_steps': 5}),
         (
             scan,
             ([], motor1, 0, 11, motor2, 10, 12, motor3, 20, 23, 5),

--- a/tests/test_scan_vars.py
+++ b/tests/test_scan_vars.py
@@ -145,6 +145,25 @@ def test_scan_vars_no_daq(RE):
             }
         ),
         (
+            grid_scan,
+            (
+                [],
+                motor1, 0, 11, 2,
+                motor2, 10, 12, 2,
+                motor3, 20, 23, 2,
+                motor, 30, 34, 2,
+            ),
+            {
+                'var0_max': 11,
+                'var1_max': 12,
+                'var2_max': 23,
+                'var0_min': 0,
+                'var1_min': 10,
+                'var2_min': 20,
+                'n_steps': 16,
+            }
+        ),
+        (
             list_scan,
             ([], motor1, [0, 1], motor2, [10, 11], motor3, [20, 21]),
             {
@@ -168,6 +187,25 @@ def test_scan_vars_no_daq(RE):
                 'var1_min': 10,
                 'var2_min': 20,
                 'n_steps': 12,
+            }
+        ),
+        (
+            list_grid_scan,
+            (
+                [],
+                motor1, [0, 1],
+                motor2, [10, 12],
+                motor3, [20, 21],
+                motor, [30, 31],
+            ),
+            {
+                'var0_max': 1,
+                'var1_max': 12,
+                'var2_max': 21,
+                'var0_min': 0,
+                'var1_min': 10,
+                'var2_min': 20,
+                'n_steps': 16,
             }
         ),
     ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add scan PV handling for the following plan patterns:
- `outer_product` (`grid_scan`)
- `inner_list_product` (`list_scan`)
- `outer_list_product` (`list_grid_scan`)

Previously, we were only handling `inner_product` (`scan`)

This should make things like `delay_scan` properly show themselves in the scan tables as per reading the metadata at https://github.com/pcdshub/nabs/blob/06d21428cddaa3f2ec6a31150f9d4758f5a7c2c5/nabs/plans.py#L92-L103, as well as cover all the most common scan cases.

This does not cover more exotic shapes like spirals, etc., but it does lay the groundwork for handling more exotic patterns.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/LCLSECSD-740
https://jira.slac.stanford.edu/browse/LCLSECSD-1069

These scan variables in old python were simply written to during the normal execution of `daq.ascan` or whatever variant we were using that day.

In the `bluesky` scheme we can be more flexible, but as a consequence we must handle the flexible cases. Rather than doing this in the plan, we do this in a callback based on document metadata.

The exact form of the metadata depends on the kind of scan we're doing, and therefore needs to be handled on a case-by-case basis (with the hope that these cases are re-used). Bluesky has a bunch of references to `plan_patterns` that define the mapping from args -> path, and we can look for these in the metadata and make decisions based on them.

After this PR, any plan with well-formed metadata like the bluesky built-ins that falls into one of these categories will know how to share start/stop/num for all the motors with the scan PVs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added tests specifically for this, but I would also like to take this for a spin in a real hutch before finalizing it.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Only in docstrings, and later in the release notes. It might be worth finding a suitable docs page to note which plan patterns we currently support.
<!--
## Screenshots (if appropriate):
-->
