### PR TITLE
MNT: consolidate exceptions and some relative imports

### DIFF
--- a/pcdsdaq/daq/__init__.py
+++ b/pcdsdaq/daq/__init__.py
@@ -17,9 +17,14 @@ Here are the available classes:
   lcls1-compatible interface for maximum parity between lcls1 and lcls2.
   It will be importable once it is ready for testing.
 """
-# flake8: noqa
-from .interface import (DaqError, DaqStateTransitionError, DaqTimeoutError,
-                        get_daq)
+from .interface import get_daq
 # from .lcls1 import DaqLCLS1  # DaqLCLS1 is not yet ready
 from .lcls2 import DaqLCLS2
 from .original import Daq  # Backcompat, will be deprecated
+
+__all__ = [
+    "get_daq",
+    "Daq",
+    # "DaqLCLS1",
+    "DaqLCLS2",
+]

--- a/pcdsdaq/daq/interface.py
+++ b/pcdsdaq/daq/interface.py
@@ -30,6 +30,7 @@ from ophyd.utils import StatusTimeoutError, WaitTimeoutError
 from pcdsdevices.interface import BaseInterface
 
 from ..ami import set_ami_hutch
+from ..exceptions import DaqTimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -88,37 +89,6 @@ class TernaryBool(IntEnum):
             return None
         else:
             return bool(self)
-
-
-class DaqError(Exception):
-    """
-    Base class for DAQ exceptions.
-
-    External users can try/except on this exception class as a catch-all for
-    DAQ-specific exceptions.
-    """
-    ...
-
-
-class DaqTimeoutError(DaqError):
-    """
-    Exception raised when the DAQ times out.
-
-    This encompasses cases where we ask for a specific action, but we observe
-    that nothing has happened for too long a duration, so we don't know
-    if the operation will ever complete.
-    """
-    ...
-
-
-class DaqStateTransitionError(DaqError):
-    """
-    Exception raised when a DAQ state transition fails.
-
-    This is distinct from a timeout where we aren't sure what's happened.
-    This is the case where we know that something definitely has gone wrong.
-    """
-    ...
 
 
 # Helper functions

--- a/pcdsdaq/daq/lcls1.py
+++ b/pcdsdaq/daq/lcls1.py
@@ -25,8 +25,8 @@ from ophyd.utils import StatusTimeoutError, WaitTimeoutError
 
 from .. import ext_scripts
 from ..ami import AmiDet, set_monitor_det, set_pyami_filter
-from .interface import (CONFIG_VAL, ControlsArg, DaqBase,
-                        DaqStateTransitionError, DaqTimeoutError, Sentinel,
+from ..exceptions import DaqStateTransitionError, DaqTimeoutError
+from .interface import (CONFIG_VAL, ControlsArg, DaqBase, Sentinel,
                         get_controls_value)
 
 logger = logging.getLogger(__name__)

--- a/pcdsdaq/daq/lcls2.py
+++ b/pcdsdaq/daq/lcls2.py
@@ -58,10 +58,10 @@ from ophyd.utils import StatusTimeoutError, WaitTimeoutError
 from ophyd.utils.errors import InvalidState
 from pcdsutils.enum import HelpfulIntEnum
 
-from .interface import (CONFIG_VAL, ControlsArg, DaqBase,
-                        DaqStateTransitionError, DaqTimeoutError, EnumId,
-                        Sentinel, TernaryBool, get_controls_name,
-                        get_controls_value, typing_check)
+from ..exceptions import DaqStateTransitionError, DaqTimeoutError
+from .interface import (CONFIG_VAL, ControlsArg, DaqBase, EnumId, Sentinel,
+                        TernaryBool, get_controls_name, get_controls_value,
+                        typing_check)
 
 try:
     from psdaq.control.ControlDef import ControlDef

--- a/pcdsdaq/daq/original.py
+++ b/pcdsdaq/daq/original.py
@@ -18,6 +18,7 @@ from ophyd.utils import StatusTimeoutError, WaitTimeoutError
 
 from .. import ext_scripts
 from ..ami import set_monitor_det, set_pyami_filter
+from ..exceptions import DaqTimeoutError
 from .interface import register_daq
 
 logger = logging.getLogger(__name__)
@@ -52,10 +53,6 @@ def check_connect(f):
             logger.error(err)
             raise RuntimeError(err)
     return wrapper
-
-
-class DaqTimeoutError(Exception):
-    pass
 
 
 class Daq:

--- a/pcdsdaq/exceptions.py
+++ b/pcdsdaq/exceptions.py
@@ -1,6 +1,30 @@
-class PcdsdaqError(Exception):
-    """Base class for pcdsdaq-related errors."""
+class DaqError(Exception):
+    """
+    Base class for DAQ or pcdsdaq-specific exceptions.
+
+    External users can try/except on this exception class as a catch-all for
+    DAQ-specific exceptions.
+    """
 
 
-class DaqNotRegisteredError(PcdsdaqError):
-    """The DAQ has not yet been registered."""
+class DaqNotRegisteredError(DaqError):
+    """The DAQ has not yet been registered and scans are unavailable."""
+
+
+class DaqTimeoutError(DaqError):
+    """
+    Exception raised when the DAQ times out.
+
+    This encompasses cases where we ask for a specific action, but we observe
+    that nothing has happened for too long a duration, so we don't know
+    if the operation will ever complete.
+    """
+
+
+class DaqStateTransitionError(DaqError):
+    """
+    Exception raised when a DAQ state transition fails.
+
+    This is distinct from a timeout where we aren't sure what's happened.
+    This is the case where we know that something definitely has gone wrong.
+    """

--- a/pcdsdaq/tests/test_daq_lcls2.py
+++ b/pcdsdaq/tests/test_daq_lcls2.py
@@ -13,8 +13,9 @@ from ophyd.signal import Signal
 from ophyd.sim import motor
 from ophyd.utils.errors import WaitTimeoutError
 
-from pcdsdaq.daq import DaqLCLS2, DaqTimeoutError
-from pcdsdaq.daq.interface import DaqStateTransitionError, TernaryBool
+from ..daq import DaqLCLS2
+from ..daq.interface import TernaryBool
+from ..exceptions import DaqStateTransitionError, DaqTimeoutError
 
 try:
     from psdaq.control.ControlDef import ControlDef

--- a/pcdsdaq/tests/test_daq_original.py
+++ b/pcdsdaq/tests/test_daq_original.py
@@ -11,12 +11,11 @@ from bluesky.plans import count
 from bluesky.preprocessors import run_wrapper, stage_wrapper
 from ophyd.status import wait as status_wait
 
-import pcdsdaq.ext_scripts as ext
-import pcdsdaq.sim.pydaq as sim_pydaq
-from pcdsdaq.daq import original as daq_module
-from pcdsdaq.daq.original import (BEGIN_TIMEOUT, DaqTimeoutError,
-                                  StateTransitionError)
-
+from .. import ext_scripts as ext
+from ..daq import original as daq_module
+from ..daq.original import BEGIN_TIMEOUT, StateTransitionError
+from ..exceptions import DaqTimeoutError
+from ..sim import pydaq as sim_pydaq
 from .conftest import skip_windows
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Move all daq exceptions into a central `pcdsdaq.exceptions` for easy importability/discoverability/etc.

## Motivation and Context
Closes #125 
Back-compat for exception imports was not retained as this is a newer structure
However this can be rectified easily if it seems worthwhile

## How Has This Been Tested?
Test suite on CI

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Issue and PR text

<!--
## Screenshots (if appropriate):
-->
