### PR TITLE
BLD: include pcdsutils dependency

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
   - bluesky >=1.6.0
   - ophyd >=1.5.0
   - pcdsdevices >=2.1.0
+  - pcdsutils
   - psdaq-control-minimal >=3.3.19
   - toolz
 

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,5 @@
 docs-versions-menu
+ipython
 sphinx
 sphinx_rtd_theme
 sphinxcontrib-jquery

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ophyd
 bluesky
 pcdsdevices
+pcdsutils
 toolz


### PR DESCRIPTION
## Description
pcdsutils is imported but not listed in the requirements
https://github.com/pcdshub/pcdsdaq/blob/22ad154ead6fd2676bb1589dca9b980e195d6661/pcdsdaq/daq/lcls2.py#L59


## Motivation and Context
Found while trying to update the nabs dependencies

## How Has This Been Tested?
CI hopefully

## Where Has This Been Documented?
This PR