### PR TITLE
BLD: unpin numpy, bluesky is npy2 compatible

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,8 +21,8 @@ requirements:
   - pip
   run:
   - python >=3.9
-  - bluesky-base =1.10.0  # Can be released when npy 2.0 compat is complete
-  - numpy <2.0.0  # dependency of other packages, needs additional pin
+  - bluesky-base
+  - numpy
   - ophyd >=1.5.0
   - pcdsdevices >=2.1.0
   - pcdsutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-bluesky==1.10.0  # avoiding broken numpy 2.0
-numpy<2.0.0
+bluesky
+numpy
 ophyd
 pcdsdevices
 pcdsutils


### PR DESCRIPTION
## Description
- unpins numpy and bluesky, compatibility work has been completed

## Motivation and Context
I dream of numpy 2, py 3.12 

## How Has This Been Tested?
CI 

## Where Has This Been Documented?
This PR